### PR TITLE
add number parsing failover for cases where device's subscriberCellularProvider == nil (e.g. iPad)

### DIFF
--- a/libPhoneNumber-iOS/NBPhoneNumberUtil.m
+++ b/libPhoneNumber-iOS/NBPhoneNumberUtil.m
@@ -3505,7 +3505,9 @@ static NSDictionary *DIGIT_MAPPINGS;
     defaultRegion = [self countryCodeByCarrier];
 #endif
     if ([UNKNOWN_REGION_ isEqualToString:defaultRegion]) {
-        //TODO: if defaultRegion is unknown get defaultRegion other way
+        // get region from device as a failover (e.g. iPad)
+        NSLocale *currentLocale = [NSLocale currentLocale];
+        defaultRegion = [currentLocale objectForKey:NSLocaleCountryCode];
     }
     
     return [self parse:numberToParse defaultRegion:defaultRegion error:error];


### PR DESCRIPTION
add failover to the convenience method parseWithPhoneCarrierRegion:error: in NBPhoneNumberUtil.m to handle cases where subscriberCellularProvider == nil (e.g. iPad)
