### PR TITLE
Previous commits not taking effect when downloaded via Cocoapods

### DIFF
--- a/libPhoneNumber/NBPhoneNumberUtil.m
+++ b/libPhoneNumber/NBPhoneNumberUtil.m
@@ -3505,7 +3505,9 @@ static NSDictionary *DIGIT_MAPPINGS;
     defaultRegion = [self countryCodeByCarrier];
 #endif
     if ([UNKNOWN_REGION_ isEqualToString:defaultRegion]) {
-        //TODO: if defaultRegion is unknown get defaultRegion other way
+        // get region from device as a failover (e.g. iPad)
+ 	NSLocale *currentLocale = [NSLocale currentLocale];
+ 	defaultRegion = [currentLocale objectForKey:NSLocaleCountryCode];
     }
     
     return [self parse:numberToParse defaultRegion:defaultRegion error:error];


### PR DESCRIPTION
The previously-merged fixes are not taking effect when using Cocoapods  - regardless of which tag or commit is targeted. This is because the code changes in the previous merge were committed in the wrong directory:

`libPhoneNumber-iOS/libPhoneNumber-iOS/`

..whereas, upon further investigation, the `.podspec` file points to this directory for its source:

`libPhoneNumber-iOS/libPhoneNumber/`

This PR repeats these recent fixes in the base directory.

Recommendations:
- To distribute this fix Cocoapods, a `0.7.4` tag must be created + associated updates to the `.podspec` file OR the `0.7.3` tag must be re-based to include these commits (probably not ideal, but perhaps appropriate since the intended fix of `0.7.3` was never actually committed to the right directory)
- It's unclear to me (and possibly future contributors) which directory to work in - or why the code is duplicated in the first place. Also the naming is unclear and similar enough to confuse even you, the author, since you did not catch this mistake from my previous commit. Highly suggest either removing the duplicate code, or renaming directories to be much more clear.

Thank you! Let me know if I can help further.
