### PR TITLE
Fixes: iOS 7 returns @"" instead of nil if sim card is missing

### DIFF
--- a/libPhoneNumber/NBPhoneNumberUtil.m
+++ b/libPhoneNumber/NBPhoneNumberUtil.m
@@ -3573,9 +3573,9 @@ static NSDictionary *DIGIT_MAPPINGS;
     
     NSString *isoCode = [[self.telephonyNetworkInfo subscriberCellularProvider] isoCountryCode];
     
-	if (!isoCode) {
-		isoCode = UNKNOWN_REGION_;
-	}
+    if (!isoCode || [isoCode isEqualToString:@""]) {
+        isoCode = UNKNOWN_REGION_;
+    }
     
     return isoCode;
 }


### PR DESCRIPTION
iOS 7 returns on isoCountryCode a empty string, the documentation says
it should return nil on missing sim card.
iOS 8 behaves correctly and returns nil if no sim card is present.
