### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@
 > ARC only, or add the **"-fobjc-arc"** flag for non-ARC
  
 ### Using [CocoaPods](http://cocoapods.org/?q=libPhoneNumber-iOS)
-> source 'https://github.com/CocoaPods/Specs.git'
-> platform :ios, "8.0"
-> pod 'libPhoneNumber-iOS', '~> 0.7'
+```
+source 'https://github.com/CocoaPods/Specs.git'
+platform :ios, "8.0"
+pod 'libPhoneNumber-iOS', '~> 0.7'
+```
 
 ### Setting up Manually
 ##### Add source files to your projects from libPhoneNumber


### PR DESCRIPTION
I am using this library with cocoapod, but have same issue with:
- https://github.com/iziz/libPhoneNumber-iOS/issues/11
- plist file exists in the bundle path, but exception occurs while unarchiveObject in my emulator. 

My solution is: 
1. update CocoaPod to the latest
2. fix Podfile and install again.
