### PR TITLE
Declared init method in header file to allow instantiation without using the singleton.

### DIFF
--- a/libPhoneNumber/NBPhoneNumberUtil.h
+++ b/libPhoneNumber/NBPhoneNumberUtil.h
@@ -21,6 +21,7 @@ extern NSString * const REGION_CODE_FOR_NON_GEO_ENTITY;
 + (NBPhoneNumberUtil*)sharedInstanceForTest;
 + (NBPhoneNumberUtil*)sharedInstanceWithBundle:(NSBundle *)bundle;
 + (NBPhoneNumberUtil*)sharedInstanceForTestWithBundle:(NSBundle *)bundle;
+- (instancetype)initWithBundle:(NSBundle *)bundle metaData:(NSString *)metaData;
 
 // regular expressions
 - (NSArray*)matchesByRegex:(NSString*)sourceString regex:(NSString*)pattern;

--- a/libPhoneNumber/NBPhoneNumberUtil.m
+++ b/libPhoneNumber/NBPhoneNumberUtil.m
@@ -497,7 +497,7 @@ static NSDictionary *DIGIT_MAPPINGS;
     return self;
 }
 
-- (id)initWithBundle:(NSBundle *)bundle metaData:(NSString *)metaData
+- (instancetype)initWithBundle:(NSBundle *)bundle metaData:(NSString *)metaData
 {
 	self = [self init];
 	if (self) {


### PR DESCRIPTION
Singletons are believed by many people to be a bad pattern. Currently there is no way to instantiate an instance of `NBPhoneNumberUtil` without using the singleton `sharedInstance` class method because the `init` method is not declared in the header file.
I cannot see any reason not to have this method public - it does not prevent anyone from using the shared instances and allows those of us who do not wish to do so to use the init method.