### PR TITLE
Fixing potential build error and module map warnings in Swift projects

### DIFF
--- a/libPhoneNumber-iOS/libPhoneNumber.h
+++ b/libPhoneNumber-iOS/libPhoneNumber.h
@@ -27,4 +27,10 @@ FOUNDATION_EXPORT const unsigned char libPhoneNumber_iOSVersionString[];
 #import "NBPhoneNumber.h"
 #import "NBPhoneNumberDesc.h"
 #import "NBNumberFormat.h"
+#import "NBAsYouTypeFormatter.h"
+
+#import "NBMetadataCore.h"
+#import "NBMetadataCoreTest.h"
+#import "NBMetadataCoreMapper.h"
+#import "NBMetadataCoreTestMapper.h"
 

--- a/libPhoneNumber.xcodeproj/project.pbxproj
+++ b/libPhoneNumber.xcodeproj/project.pbxproj
@@ -41,9 +41,9 @@
 		34ACBBC01B71255D0064B3BD /* NBMetadataCoreMapper.h in Headers */ = {isa = PBXBuildFile; fileRef = FDBCFA0A1A87AD8C00297F21 /* NBMetadataCoreMapper.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		34ACBBC11B7125670064B3BD /* NBMetadataCoreTestMapper.h in Headers */ = {isa = PBXBuildFile; fileRef = FDBCFA0E1A87ADA300297F21 /* NBMetadataCoreTestMapper.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		34ACBBC21B71256C0064B3BD /* NBMetadataCoreTestMapper.m in Sources */ = {isa = PBXBuildFile; fileRef = FDBCFA0F1A87ADA300297F21 /* NBMetadataCoreTestMapper.m */; };
-		34ACBBC31B71257F0064B3BD /* NSArray+NBAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = FD8B84331934C35F00C350EB /* NSArray+NBAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8F04BE90176F062500076CB4 /* NBAsYouTypeFormatterTest1.m in Sources */ = {isa = PBXBuildFile; fileRef = FD57B66C16E5B71F000772AF /* NBAsYouTypeFormatterTest1.m */; };
 		8FB1926F18E2B8CB000520E7 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FDAD44B418E11B300041825C /* XCTest.framework */; };
+		AF0C04111B739A0700F4B5DD /* NBPhoneMetaDataGenerator.h in Headers */ = {isa = PBXBuildFile; fileRef = FD7A066D167736BD004BBEB6 /* NBPhoneMetaDataGenerator.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		FD12C26A1A87401B00B53856 /* NBMetadataHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = FD12C2691A87401B00B53856 /* NBMetadataHelper.m */; };
 		FD12C26B1A87401B00B53856 /* NBMetadataHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = FD12C2691A87401B00B53856 /* NBMetadataHelper.m */; };
 		FD12C26E1A87546400B53856 /* NBMetadataCore.m in Sources */ = {isa = PBXBuildFile; fileRef = FD12C26D1A87546400B53856 /* NBMetadataCore.m */; };
@@ -359,12 +359,12 @@
 				34ACBBBD1B7125450064B3BD /* NBAsYouTypeFormatter.h in Headers */,
 				34ACBBBA1B7124E40064B3BD /* NBPhoneMetaData.h in Headers */,
 				34ACBBBF1B7125570064B3BD /* NBMetadataCoreTest.h in Headers */,
-				34ACBBC31B71257F0064B3BD /* NSArray+NBAdditions.h in Headers */,
 				34ACBBC01B71255D0064B3BD /* NBMetadataCoreMapper.h in Headers */,
 				34ACBBBC1B7125290064B3BD /* NBMetadataHelper.h in Headers */,
 				34ACBBB81B7124D10064B3BD /* NBNumberFormat.h in Headers */,
 				34ACBB8A1B7122AC0064B3BD /* libPhoneNumber.h in Headers */,
 				34ACBBB61B7124AB0064B3BD /* NBPhoneNumberDefines.h in Headers */,
+				AF0C04111B739A0700F4B5DD /* NBPhoneMetaDataGenerator.h in Headers */,
 				34ACBBB71B7124BE0064B3BD /* NBPhoneNumber.h in Headers */,
 				34ACBBBB1B7124EF0064B3BD /* NBPhoneNumberUtil.h in Headers */,
 				34ACBBBE1B7125520064B3BD /* NBMetadataCore.h in Headers */,


### PR DESCRIPTION
Having headers included in the framework but not imported in libPhoneNumber.h causes umbrella header module map warnings.