### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,12 @@ override func viewDidLoad() {
     let phoneUtil = NBPhoneNumberUtil()
 
     var errorPointer:NSError?
-    var number:NBPhoneNumber = phoneUtil.parse("01041241282", defaultRegion:"KR", error:&errorPointer)
-
-    NSLog("%@", number)
+    var number:NBPhoneNumber? = phoneUtil.parse("01041241282", defaultRegion:"KR", error:&errorPointer)
+    if errorPointer == nil && number != nil {
+       println("number is: \(number)")
+    } else {
+       println("number error: \(errorPointer?.localizedDescription)")
+    }
 }
 ```
 


### PR DESCRIPTION
When errors occurred the parse method would return nil. Therefore if the variable taking the return value isn't optional it will have a fatal exception.