### PR TITLE
Use NS_ENUM for better Swift interoperability

### DIFF
--- a/libPhoneNumber/NBPhoneNumber.m
+++ b/libPhoneNumber/NBPhoneNumber.m
@@ -37,7 +37,7 @@
         return NBECountryCodeSourceFROM_NUMBER_WITH_PLUS_SIGN;
     }
     
-    return [self.countryCodeSource intValue];
+    return [self.countryCodeSource integerValue];
 }
 
 
@@ -113,7 +113,7 @@
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@" - countryCode[%@], nationalNumber[%@], extension[%@], italianLeadingZero[%@], rawInput[%@] countryCodeSource[%d] preferredDomesticCarrierCode[%@]", self.countryCode, self.nationalNumber, self.extension, self.italianLeadingZero?@"Y":@"N", self.rawInput, [self.countryCodeSource intValue], self.preferredDomesticCarrierCode];
+    return [NSString stringWithFormat:@" - countryCode[%@], nationalNumber[%@], extension[%@], italianLeadingZero[%@], rawInput[%@] countryCodeSource[%@] preferredDomesticCarrierCode[%@]", self.countryCode, self.nationalNumber, self.extension, self.italianLeadingZero?@"Y":@"N", self.rawInput, self.countryCodeSource, self.preferredDomesticCarrierCode];
 }
 
 @end

--- a/libPhoneNumber/NBPhoneNumberDefines.h
+++ b/libPhoneNumber/NBPhoneNumberDefines.h
@@ -12,15 +12,15 @@
 
 #pragma mark - Enum -
 
-typedef enum {
+typedef NS_ENUM(NSInteger, NBEPhoneNumberFormat) {
     NBEPhoneNumberFormatE164 = 0,
     NBEPhoneNumberFormatINTERNATIONAL = 1,
     NBEPhoneNumberFormatNATIONAL = 2,
     NBEPhoneNumberFormatRFC3966 = 3
-} NBEPhoneNumberFormat;
+};
 
 
-typedef enum {
+typedef NS_ENUM(NSInteger, NBEPhoneNumberType) {
     NBEPhoneNumberTypeFIXED_LINE = 0,
     NBEPhoneNumberTypeMOBILE = 1,
     // In some regions (e.g. the USA), it is impossible to distinguish between
@@ -49,33 +49,33 @@ typedef enum {
     // A phone number is of type UNKNOWN when it does not fit any of the known
     // patterns for a specific region.
     NBEPhoneNumberTypeUNKNOWN = -1
-} NBEPhoneNumberType;
+};
 
 
-typedef enum {
+typedef NS_ENUM(NSInteger, NBEMatchType) {
     NBEMatchTypeNOT_A_NUMBER = 0,
     NBEMatchTypeNO_MATCH = 1,
     NBEMatchTypeSHORT_NSN_MATCH = 2,
     NBEMatchTypeNSN_MATCH = 3,
     NBEMatchTypeEXACT_MATCH = 4
-} NBEMatchType;
+};
 
 
-typedef enum {
+typedef NS_ENUM(NSInteger, NBEValidationResult) {
     NBEValidationResultUNKNOWN = 0,
     NBEValidationResultIS_POSSIBLE = 1,
     NBEValidationResultINVALID_COUNTRY_CODE = 2,
     NBEValidationResultTOO_SHORT = 3,
     NBEValidationResultTOO_LONG = 4
-} NBEValidationResult;
+};
 
 
-typedef enum {
+typedef NS_ENUM(NSInteger, NBECountryCodeSource) {
     NBECountryCodeSourceFROM_NUMBER_WITH_PLUS_SIGN = 1,
     NBECountryCodeSourceFROM_NUMBER_WITH_IDD = 5,
     NBECountryCodeSourceFROM_NUMBER_WITHOUT_PLUS_SIGN = 10,
     NBECountryCodeSourceFROM_DEFAULT_COUNTRY = 20
-} NBECountryCodeSource;
+};
 
 static NSString *NB_NON_BREAKING_SPACE = @"\u00a0";
 static NSString *NB_PLUS_CHARS = @"+＋";

--- a/libPhoneNumber/NBPhoneNumberUtil.m
+++ b/libPhoneNumber/NBPhoneNumberUtil.m
@@ -1552,7 +1552,7 @@ static NSDictionary *DIGIT_MAPPINGS;
     
     NSString *formattedNumber = @"";
     
-    switch ([number.countryCodeSource intValue])
+    switch ([number.countryCodeSource integerValue])
     {
         case NBECountryCodeSourceFROM_NUMBER_WITH_PLUS_SIGN:
             formattedNumber = [self format:number numberFormat:NBEPhoneNumberFormatINTERNATIONAL];
@@ -2945,7 +2945,7 @@ static NSDictionary *DIGIT_MAPPINGS;
     NBECountryCodeSource countryCodeSource = [self maybeStripInternationalPrefixAndNormalize:&fullNumber
                                                                            possibleIddPrefix:possibleCountryIddPrefix];
     if (keepRawInput) {
-        (*phoneNumber).countryCodeSource = [NSNumber numberWithInt:countryCodeSource];
+        (*phoneNumber).countryCodeSource = [NSNumber numberWithInteger:countryCodeSource];
     }
     
     if (countryCodeSource != NBECountryCodeSourceFROM_DEFAULT_COUNTRY) {
@@ -3000,7 +3000,7 @@ static NSDictionary *DIGIT_MAPPINGS;
                 [self testNumberLengthAgainstPattern:possibleNumberPattern number:fullNumber] == NBEValidationResultTOO_LONG) {
                 (*nationalNumber) = [(*nationalNumber) stringByAppendingString:potentialNationalNumberStr];
                 if (keepRawInput) {
-                    (*phoneNumber).countryCodeSource = [NSNumber numberWithInt:NBECountryCodeSourceFROM_NUMBER_WITHOUT_PLUS_SIGN];
+                    (*phoneNumber).countryCodeSource = [NSNumber numberWithInteger:NBECountryCodeSourceFROM_NUMBER_WITHOUT_PLUS_SIGN];
                 }
                 (*phoneNumber).countryCode = defaultCountryCode;
                 return defaultCountryCode;

--- a/libPhoneNumberTests/NBPhoneNumberUtilTest2.m
+++ b/libPhoneNumberTests/NBPhoneNumberUtilTest2.m
@@ -229,13 +229,13 @@
             NSError *anError = nil;
             XCTAssertEqualObjects(countryCallingCode, [_aUtil maybeExtractCountryCode:phoneNumber metadata:metadata
                                                                        nationalNumber:&numberToFill keepRawInput:YES phoneNumber:&number error:&anError]);
-            XCTAssertEqual(NBECountryCodeSourceFROM_NUMBER_WITH_IDD, [number.countryCodeSource intValue]);
+            XCTAssertEqual(NBECountryCodeSourceFROM_NUMBER_WITH_IDD, [number.countryCodeSource integerValue]);
             // Should strip and normalize national significant number.
             XCTAssertEqualObjects(strippedNumber, numberToFill);
             if (anError)
                 XCTFail(@"Should not have thrown an exception: %@", anError.description);
         }
-        XCTAssertEqual(NBECountryCodeSourceFROM_NUMBER_WITH_IDD, [number.countryCodeSource intValue], @"Did not figure out CountryCodeSource correctly");
+        XCTAssertEqual(NBECountryCodeSourceFROM_NUMBER_WITH_IDD, [number.countryCodeSource integerValue], @"Did not figure out CountryCodeSource correctly");
         // Should strip and normalize national significant number.
         XCTAssertEqualObjects(strippedNumber, numberToFill, @"Did not strip off the country calling code correctly.");
         
@@ -245,7 +245,7 @@
         numberToFill = @"";
         XCTAssertEqualObjects(countryCallingCode, [_aUtil maybeExtractCountryCode:phoneNumber metadata:metadata
                                                                    nationalNumber:&numberToFill keepRawInput:YES phoneNumber:&number error:nil]);
-        XCTAssertEqual(NBECountryCodeSourceFROM_NUMBER_WITH_PLUS_SIGN, [number.countryCodeSource intValue], @"Did not figure out CountryCodeSource correctly");
+        XCTAssertEqual(NBECountryCodeSourceFROM_NUMBER_WITH_PLUS_SIGN, [number.countryCodeSource integerValue], @"Did not figure out CountryCodeSource correctly");
         
         number = [[NBPhoneNumber alloc] init];
         phoneNumber = @"+80012345678";
@@ -253,14 +253,14 @@
         numberToFill = @"";
         XCTAssertEqualObjects(countryCallingCode, [_aUtil maybeExtractCountryCode:phoneNumber metadata:metadata
                                                                    nationalNumber:&numberToFill keepRawInput:YES phoneNumber:&number error:nil]);
-        XCTAssertEqual(NBECountryCodeSourceFROM_NUMBER_WITH_PLUS_SIGN, [number.countryCodeSource intValue], @"Did not figure out CountryCodeSource correctly");
+        XCTAssertEqual(NBECountryCodeSourceFROM_NUMBER_WITH_PLUS_SIGN, [number.countryCodeSource integerValue], @"Did not figure out CountryCodeSource correctly");
         
         number = [[NBPhoneNumber alloc] init];
         phoneNumber = @"2345-6789";
         numberToFill = @"";
         XCTAssertEqual(@0, [_aUtil maybeExtractCountryCode:phoneNumber metadata:metadata
                                             nationalNumber:&numberToFill keepRawInput:YES phoneNumber:&number error:nil]);
-        XCTAssertEqual(NBECountryCodeSourceFROM_DEFAULT_COUNTRY, [number.countryCodeSource intValue], @"Did not figure out CountryCodeSource correctly");
+        XCTAssertEqual(NBECountryCodeSourceFROM_DEFAULT_COUNTRY, [number.countryCodeSource integerValue], @"Did not figure out CountryCodeSource correctly");
         
         
         number = [[NBPhoneNumber alloc] init];
@@ -285,7 +285,7 @@
             XCTAssertEqualObjects(countryCallingCode, [_aUtil maybeExtractCountryCode:phoneNumber metadata:metadata
                                                                        nationalNumber:&numberToFill keepRawInput:YES phoneNumber:&number error:&anError],
                                   @"Should have extracted the country calling code of the region passed in");
-            XCTAssertEqual(NBECountryCodeSourceFROM_NUMBER_WITHOUT_PLUS_SIGN, [number.countryCodeSource intValue], @"Did not figure out CountryCodeSource correctly");
+            XCTAssertEqual(NBECountryCodeSourceFROM_NUMBER_WITHOUT_PLUS_SIGN, [number.countryCodeSource integerValue], @"Did not figure out CountryCodeSource correctly");
         }
         
         number = [[NBPhoneNumber alloc] init];
@@ -315,7 +315,7 @@
             NSError *anError = nil;
             XCTAssertEqual(@0, [_aUtil maybeExtractCountryCode:phoneNumber metadata:metadata
                                                 nationalNumber:&numberToFill keepRawInput:YES phoneNumber:&number error:&anError]);
-            XCTAssertEqual(NBECountryCodeSourceFROM_DEFAULT_COUNTRY, [number.countryCodeSource intValue]);
+            XCTAssertEqual(NBECountryCodeSourceFROM_DEFAULT_COUNTRY, [number.countryCodeSource integerValue]);
         }
     }
 
@@ -886,7 +886,7 @@
         
         id nzNumberWithRawInput = [NZ_NUMBER copy];
         [nzNumberWithRawInput setRawInput:@"+64 3 331 6005"];
-        [nzNumberWithRawInput setCountryCodeSource:[NSNumber numberWithInt:NBECountryCodeSourceFROM_NUMBER_WITH_PLUS_SIGN]];
+        [nzNumberWithRawInput setCountryCodeSource:[NSNumber numberWithInteger:NBECountryCodeSourceFROM_NUMBER_WITH_PLUS_SIGN]];
         [nzNumberWithRawInput setPreferredDomesticCarrierCode:@""];
         XCTAssertTrue([nzNumberWithRawInput isEqual:[_aUtil parseAndKeepRawInput:@"+64 3 331 6005" defaultRegion:@"ZZ" error:&anError]]);
         // nil is also allowed for the region code in these cases.
@@ -986,7 +986,7 @@
         NSLog(@"-------------- testParseAndKeepRaw");
         NBPhoneNumber *alphaNumericNumber = [ALPHA_NUMERIC_NUMBER copy];
         [alphaNumericNumber setRawInput:@"800 six-flags"];
-        [alphaNumericNumber setCountryCodeSource:[NSNumber numberWithInt:NBECountryCodeSourceFROM_DEFAULT_COUNTRY]];
+        [alphaNumericNumber setCountryCodeSource:[NSNumber numberWithInteger:NBECountryCodeSourceFROM_DEFAULT_COUNTRY]];
         [alphaNumericNumber setPreferredDomesticCarrierCode:@""];
         XCTAssertTrue([alphaNumericNumber isEqual:[_aUtil parseAndKeepRawInput:@"800 six-flags" defaultRegion:@"US" error:&anError]]);
         
@@ -994,18 +994,18 @@
         [shorterAlphaNumber setCountryCode:@1];
         [shorterAlphaNumber setNationalNumber:@8007493524];
         [shorterAlphaNumber setRawInput:@"1800 six-flag"];
-        [shorterAlphaNumber setCountryCodeSource:[NSNumber numberWithInt:NBECountryCodeSourceFROM_NUMBER_WITHOUT_PLUS_SIGN]];
+        [shorterAlphaNumber setCountryCodeSource:[NSNumber numberWithInteger:NBECountryCodeSourceFROM_NUMBER_WITHOUT_PLUS_SIGN]];
         [shorterAlphaNumber setPreferredDomesticCarrierCode:@""];
         XCTAssertTrue([shorterAlphaNumber isEqual:[_aUtil parseAndKeepRawInput:@"1800 six-flag" defaultRegion:@"US" error:&anError]]);
         
         [shorterAlphaNumber setRawInput:@"+1800 six-flag"];
-        [shorterAlphaNumber setCountryCodeSource:[NSNumber numberWithInt:NBECountryCodeSourceFROM_NUMBER_WITH_PLUS_SIGN]];
+        [shorterAlphaNumber setCountryCodeSource:[NSNumber numberWithInteger:NBECountryCodeSourceFROM_NUMBER_WITH_PLUS_SIGN]];
         XCTAssertTrue([shorterAlphaNumber isEqual:[_aUtil parseAndKeepRawInput:@"+1800 six-flag" defaultRegion:@"NZ" error:&anError]]);
         
         [alphaNumericNumber setCountryCode:@1];
         [alphaNumericNumber setNationalNumber:@8007493524];
         [alphaNumericNumber setRawInput:@"001800 six-flag"];
-        [alphaNumericNumber setCountryCodeSource:[NSNumber numberWithInt:NBECountryCodeSourceFROM_NUMBER_WITH_IDD]];
+        [alphaNumericNumber setCountryCodeSource:[NSNumber numberWithInteger:NBECountryCodeSourceFROM_NUMBER_WITH_IDD]];
         XCTAssertTrue([alphaNumericNumber isEqual:[_aUtil parseAndKeepRawInput:@"001800 six-flag" defaultRegion:@"NZ" error:&anError]]);
         
         // Invalid region code supplied.
@@ -1023,7 +1023,7 @@
         [koreanNumber setCountryCode:@82];
         [koreanNumber setNationalNumber:@22123456];
         [koreanNumber setRawInput:@"08122123456"];
-        [koreanNumber setCountryCodeSource:[NSNumber numberWithInt:NBECountryCodeSourceFROM_DEFAULT_COUNTRY]];
+        [koreanNumber setCountryCodeSource:[NSNumber numberWithInteger:NBECountryCodeSourceFROM_DEFAULT_COUNTRY]];
         [koreanNumber setPreferredDomesticCarrierCode:@"81"];
         XCTAssertTrue([koreanNumber isEqual:[_aUtil parseAndKeepRawInput:@"08122123456" defaultRegion:@"KR" error:&anError]]);
     }
@@ -1101,12 +1101,12 @@
         NBPhoneNumber *brNumberTwo = [[NBPhoneNumber alloc] init];
         [brNumberOne setCountryCode:@55];
         [brNumberOne setNationalNumber:@3121286979];
-        [brNumberOne setCountryCodeSource:[NSNumber numberWithInt:NBECountryCodeSourceFROM_NUMBER_WITH_PLUS_SIGN]];
+        [brNumberOne setCountryCodeSource:[NSNumber numberWithInteger:NBECountryCodeSourceFROM_NUMBER_WITH_PLUS_SIGN]];
         [brNumberOne setPreferredDomesticCarrierCode:@"12"];
         [brNumberOne setRawInput:@"012 3121286979"];
         [brNumberTwo setCountryCode:@55];
         [brNumberTwo setNationalNumber:@3121286979];
-        [brNumberTwo setCountryCodeSource:[NSNumber numberWithInt:NBECountryCodeSourceFROM_DEFAULT_COUNTRY]];
+        [brNumberTwo setCountryCodeSource:[NSNumber numberWithInteger:NBECountryCodeSourceFROM_DEFAULT_COUNTRY]];
         [brNumberTwo setPreferredDomesticCarrierCode:@"14"];
         [brNumberTwo setRawInput:@"143121286979"];
         XCTAssertEqual(NBEMatchTypeEXACT_MATCH, [_aUtil isNumberMatch:brNumberOne second:brNumberTwo]);


### PR DESCRIPTION
Objective-C enums that are defined with the NS_ENUM macro are automatically imported
into Swift as Swift enumerations. This allows for easier usage of the enums in Swift.
In addition to wrapping all enum declarations into NS_ENUM, this commit also makes
sure that the correct factory method is used when converting between enum constants
and NSNumbers.