### PR TITLE
Use external linkage & const pointers for shared string constants and make unknown region code public

### DIFF
--- a/libPhoneNumber.xcodeproj/project.pbxproj
+++ b/libPhoneNumber.xcodeproj/project.pbxproj
@@ -44,6 +44,9 @@
 		738BED431BCC73200048B813 /* NSArray+NBAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = FD8B84331934C35F00C350EB /* NSArray+NBAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8F04BE90176F062500076CB4 /* NBAsYouTypeFormatterTest1.m in Sources */ = {isa = PBXBuildFile; fileRef = FD57B66C16E5B71F000772AF /* NBAsYouTypeFormatterTest1.m */; };
 		8FB1926F18E2B8CB000520E7 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FDAD44B418E11B300041825C /* XCTest.framework */; };
+		A81D6A291BECC43A00F68F34 /* NBPhoneNumberDefines.m in Sources */ = {isa = PBXBuildFile; fileRef = A81D6A281BECC43A00F68F34 /* NBPhoneNumberDefines.m */; };
+		A81D6A2A1BECC44500F68F34 /* NBPhoneNumberDefines.m in Sources */ = {isa = PBXBuildFile; fileRef = A81D6A281BECC43A00F68F34 /* NBPhoneNumberDefines.m */; };
+		A81D6A2B1BECC44600F68F34 /* NBPhoneNumberDefines.m in Sources */ = {isa = PBXBuildFile; fileRef = A81D6A281BECC43A00F68F34 /* NBPhoneNumberDefines.m */; };
 		AF0C04111B739A0700F4B5DD /* NBPhoneMetaDataGenerator.h in Headers */ = {isa = PBXBuildFile; fileRef = FD7A066D167736BD004BBEB6 /* NBPhoneMetaDataGenerator.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		FD12C26A1A87401B00B53856 /* NBMetadataHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = FD12C2691A87401B00B53856 /* NBMetadataHelper.m */; };
 		FD12C26B1A87401B00B53856 /* NBMetadataHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = FD12C2691A87401B00B53856 /* NBMetadataHelper.m */; };
@@ -107,6 +110,7 @@
 		34ACBB881B7122AC0064B3BD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		34ACBB891B7122AC0064B3BD /* libPhoneNumber.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = libPhoneNumber.h; sourceTree = "<group>"; };
 		4D43EF831740825100C24FF3 /* libPhoneNumber-iOS.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = "libPhoneNumber-iOS.podspec"; sourceTree = SOURCE_ROOT; };
+		A81D6A281BECC43A00F68F34 /* NBPhoneNumberDefines.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = NBPhoneNumberDefines.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		FD12C2681A87401B00B53856 /* NBMetadataHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NBMetadataHelper.h; sourceTree = "<group>"; };
 		FD12C2691A87401B00B53856 /* NBMetadataHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NBMetadataHelper.m; sourceTree = "<group>"; };
 		FD12C26C1A87546400B53856 /* NBMetadataCore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NBMetadataCore.h; sourceTree = "<group>"; };
@@ -114,7 +118,7 @@
 		FD2014DC169A8A82003491D9 /* index.php */ = {isa = PBXFileReference; lastKnownFileType = text.script.php; name = index.php; path = libPhoneNumberTests/index.php; sourceTree = SOURCE_ROOT; };
 		FD2014DD169A8A82003491D9 /* libPhoneNumberGenerator.php */ = {isa = PBXFileReference; lastKnownFileType = text.script.php; name = libPhoneNumberGenerator.php; path = libPhoneNumberTests/libPhoneNumberGenerator.php; sourceTree = SOURCE_ROOT; };
 		FD379E291A8AE5150015C184 /* NBPhoneNumberMetadata.plist */ = {isa = PBXFileReference; lastKnownFileType = file.bplist; path = NBPhoneNumberMetadata.plist; sourceTree = "<group>"; };
-		FD57B66C16E5B71F000772AF /* NBAsYouTypeFormatterTest1.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NBAsYouTypeFormatterTest1.m; sourceTree = "<group>"; };
+		FD57B66C16E5B71F000772AF /* NBAsYouTypeFormatterTest1.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = NBAsYouTypeFormatterTest1.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		FD7A061C167715A0004BBEB6 /* libPhoneNumber.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = libPhoneNumber.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		FD7A0620167715A0004BBEB6 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		FD7A0622167715A0004BBEB6 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
@@ -124,14 +128,14 @@
 		FD7A062C167715A0004BBEB6 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		FD7A062E167715A0004BBEB6 /* libPhoneNumber-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "libPhoneNumber-Prefix.pch"; sourceTree = "<group>"; };
 		FD7A062F167715A0004BBEB6 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
-		FD7A0630167715A0004BBEB6 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		FD7A0630167715A0004BBEB6 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AppDelegate.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		FD7A0632167715A0004BBEB6 /* Default.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Default.png; sourceTree = "<group>"; };
 		FD7A0634167715A0004BBEB6 /* Default@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default@2x.png"; sourceTree = "<group>"; };
 		FD7A0636167715A0004BBEB6 /* Default-568h@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default-568h@2x.png"; sourceTree = "<group>"; };
 		FD7A063D167715A1004BBEB6 /* libPhoneNumberTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = libPhoneNumberTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		FD7A0646167715A1004BBEB6 /* libPhoneNumberTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "libPhoneNumberTests-Info.plist"; sourceTree = "<group>"; };
 		FD7A0648167715A1004BBEB6 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		FD7A064B167715A1004BBEB6 /* NBPhoneNumberUtilTest1.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NBPhoneNumberUtilTest1.m; sourceTree = "<group>"; };
+		FD7A064B167715A1004BBEB6 /* NBPhoneNumberUtilTest1.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = NBPhoneNumberUtilTest1.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		FD7A066D167736BD004BBEB6 /* NBPhoneMetaDataGenerator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NBPhoneMetaDataGenerator.h; sourceTree = "<group>"; };
 		FD7A066E167736BD004BBEB6 /* NBPhoneMetaDataGenerator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NBPhoneMetaDataGenerator.m; sourceTree = "<group>"; };
 		FD8B84261934C35F00C350EB /* NBAsYouTypeFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NBAsYouTypeFormatter.h; sourceTree = "<group>"; };
@@ -142,11 +146,11 @@
 		FD8B842B1934C35F00C350EB /* NBPhoneMetaData.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NBPhoneMetaData.m; sourceTree = "<group>"; };
 		FD8B842C1934C35F00C350EB /* NBPhoneNumber.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NBPhoneNumber.h; sourceTree = "<group>"; };
 		FD8B842D1934C35F00C350EB /* NBPhoneNumber.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NBPhoneNumber.m; sourceTree = "<group>"; };
-		FD8B842E1934C35F00C350EB /* NBPhoneNumberDefines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NBPhoneNumberDefines.h; sourceTree = "<group>"; };
+		FD8B842E1934C35F00C350EB /* NBPhoneNumberDefines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = NBPhoneNumberDefines.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		FD8B842F1934C35F00C350EB /* NBPhoneNumberDesc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NBPhoneNumberDesc.h; sourceTree = "<group>"; };
 		FD8B84301934C35F00C350EB /* NBPhoneNumberDesc.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NBPhoneNumberDesc.m; sourceTree = "<group>"; };
 		FD8B84311934C35F00C350EB /* NBPhoneNumberUtil.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NBPhoneNumberUtil.h; sourceTree = "<group>"; };
-		FD8B84321934C35F00C350EB /* NBPhoneNumberUtil.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NBPhoneNumberUtil.m; sourceTree = "<group>"; };
+		FD8B84321934C35F00C350EB /* NBPhoneNumberUtil.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = NBPhoneNumberUtil.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		FD8B84331934C35F00C350EB /* NSArray+NBAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSArray+NBAdditions.h"; sourceTree = "<group>"; };
 		FD8B84341934C35F00C350EB /* NSArray+NBAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSArray+NBAdditions.m"; sourceTree = "<group>"; };
 		FDAD44B418E11B300041825C /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
@@ -154,7 +158,7 @@
 		FDBCFA0B1A87AD8C00297F21 /* NBMetadataCoreMapper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NBMetadataCoreMapper.m; sourceTree = "<group>"; };
 		FDBCFA0E1A87ADA300297F21 /* NBMetadataCoreTestMapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NBMetadataCoreTestMapper.h; sourceTree = "<group>"; };
 		FDBCFA0F1A87ADA300297F21 /* NBMetadataCoreTestMapper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NBMetadataCoreTestMapper.m; sourceTree = "<group>"; };
-		FDE51F9E1B6FBA19002D9798 /* NBPhoneNumberUtilTest2.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NBPhoneNumberUtilTest2.m; sourceTree = "<group>"; };
+		FDE51F9E1B6FBA19002D9798 /* NBPhoneNumberUtilTest2.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = NBPhoneNumberUtilTest2.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		FDE51FA01B6FD26C002D9798 /* NBAsYouTypeFormatterTest2.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NBAsYouTypeFormatterTest2.m; sourceTree = "<group>"; };
 		FDF1ED951A8774DC00F6123A /* NBMetadataCoreTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NBMetadataCoreTest.h; sourceTree = "<group>"; };
 		FDF1ED961A8774DC00F6123A /* NBMetadataCoreTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NBMetadataCoreTest.m; sourceTree = "<group>"; };
@@ -324,6 +328,7 @@
 				FDBCFA121A87ADAB00297F21 /* Meatadata */,
 				FD12C2711A8759AF00B53856 /* Model */,
 				FD8B842E1934C35F00C350EB /* NBPhoneNumberDefines.h */,
+				A81D6A281BECC43A00F68F34 /* NBPhoneNumberDefines.m */,
 				FD8B84311934C35F00C350EB /* NBPhoneNumberUtil.h */,
 				FD8B84321934C35F00C350EB /* NBPhoneNumberUtil.m */,
 				FD12C2681A87401B00B53856 /* NBMetadataHelper.h */,
@@ -534,6 +539,7 @@
 				34ACBBAD1B7123020064B3BD /* NBPhoneMetaData.m in Sources */,
 				34ACBBB01B71230E0064B3BD /* NBAsYouTypeFormatter.m in Sources */,
 				34ACBBC21B71256C0064B3BD /* NBMetadataCoreTestMapper.m in Sources */,
+				A81D6A2B1BECC44600F68F34 /* NBPhoneNumberDefines.m in Sources */,
 				34ACBBB31B7123620064B3BD /* NBPhoneMetaDataGenerator.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -544,6 +550,7 @@
 			files = (
 				FDBCFA101A87ADA300297F21 /* NBMetadataCoreTestMapper.m in Sources */,
 				FDBCFA0C1A87AD8C00297F21 /* NBMetadataCoreMapper.m in Sources */,
+				A81D6A291BECC43A00F68F34 /* NBPhoneNumberDefines.m in Sources */,
 				FDBCFA091A87A0B200297F21 /* NBMetadataCoreTest.m in Sources */,
 				FD8B84451934C35F00C350EB /* NBPhoneNumberDesc.m in Sources */,
 				FD8B84411934C35F00C350EB /* NBPhoneMetaData.m in Sources */,
@@ -565,6 +572,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				FDBCFA081A87A0AC00297F21 /* NBMetadataCore.m in Sources */,
+				A81D6A2A1BECC44500F68F34 /* NBPhoneNumberDefines.m in Sources */,
 				8F04BE90176F062500076CB4 /* NBAsYouTypeFormatterTest1.m in Sources */,
 				FDBCFA111A87ADA300297F21 /* NBMetadataCoreTestMapper.m in Sources */,
 				FD12C26B1A87401B00B53856 /* NBMetadataHelper.m in Sources */,

--- a/libPhoneNumber/AppDelegate.m
+++ b/libPhoneNumber/AppDelegate.m
@@ -82,7 +82,7 @@
     
     {
         NSError *error = nil;
-        NBPhoneNumber *phoneNumberZZ = [phoneUtil parse:@"+84 74 883313" defaultRegion:@"ZZ" error:&error];
+        NBPhoneNumber *phoneNumberZZ = [phoneUtil parse:@"+84 74 883313" defaultRegion:NB_UNKNOWN_REGION error:&error];
         if (error) {
             NSLog(@"err [%@]", [error localizedDescription]);
         }

--- a/libPhoneNumber/NBPhoneNumberDefines.h
+++ b/libPhoneNumber/NBPhoneNumberDefines.h
@@ -77,9 +77,10 @@ typedef enum {
     NBECountryCodeSourceFROM_DEFAULT_COUNTRY = 20
 } NBECountryCodeSource;
 
-static NSString *NB_NON_BREAKING_SPACE = @"\u00a0";
-static NSString *NB_PLUS_CHARS = @"+＋";
-static NSString *NB_VALID_DIGITS_STRING = @"0-9０-９٠-٩۰-۹";
-static NSString *NB_REGION_CODE_FOR_NON_GEO_ENTITY = @"001";
+extern NSString * const NB_UNKNOWN_REGION;
+extern NSString * const NB_NON_BREAKING_SPACE;
+extern NSString * const NB_PLUS_CHARS;
+extern NSString * const NB_VALID_DIGITS_STRING;
+extern NSString * const NB_REGION_CODE_FOR_NON_GEO_ENTITY;
 
 #endif

--- a/libPhoneNumber/NBPhoneNumberDefines.m
+++ b/libPhoneNumber/NBPhoneNumberDefines.m
@@ -1,0 +1,7 @@
+#import "NBPhoneNumberDefines.h"
+
+NSString * const NB_UNKNOWN_REGION = @"ZZ";
+NSString * const NB_NON_BREAKING_SPACE = @"\u00a0";
+NSString * const NB_PLUS_CHARS = @"+＋";
+NSString * const NB_VALID_DIGITS_STRING = @"0-9０-９٠-٩۰-۹";
+NSString * const NB_REGION_CODE_FOR_NON_GEO_ENTITY = @"001";

--- a/libPhoneNumber/NBPhoneNumberUtil.m
+++ b/libPhoneNumber/NBPhoneNumberUtil.m
@@ -63,7 +63,6 @@ static NSString *TOO_SHORT_AFTER_IDD_STR = @"Phone number too short after IDD";
 static NSString *TOO_SHORT_NSN_STR = @"The string supplied is too short to be a phone number";
 static NSString *TOO_LONG_STR = @"The string supplied is too long to be a phone number";
 
-static NSString *UNKNOWN_REGION_ = @"ZZ";
 static NSString *COLOMBIA_MOBILE_TO_FIXED_LINE_PREFIX = @"3";
 static NSString *PLUS_SIGN = @"+";
 static NSString *STAR_SIGN = @"*";
@@ -2035,7 +2034,7 @@ static NSDictionary *DIGIT_MAPPINGS;
         NBPhoneNumberDesc *desc = metadata.generalDesc;
         if ([NBMetadataHelper hasValue:desc.exampleNumber]) {
             NSString *callCode = [NSString stringWithFormat:@"+%@%@", countryCallingCode, desc.exampleNumber];
-            return [self parse:callCode defaultRegion:UNKNOWN_REGION_ error:error];
+            return [self parse:callCode defaultRegion:NB_UNKNOWN_REGION error:error];
         }
     }
     
@@ -2397,7 +2396,7 @@ static NSDictionary *DIGIT_MAPPINGS;
 {
     NBMetadataHelper *helper = [[NBMetadataHelper alloc] init];
     NSArray *regionCodes = [helper regionCodeFromCountryCode:countryCallingCode];
-    return regionCodes == nil ? UNKNOWN_REGION_ : [regionCodes objectAtIndex:0];
+    return regionCodes == nil ? NB_UNKNOWN_REGION : [regionCodes objectAtIndex:0];
 }
 
 
@@ -3290,7 +3289,7 @@ static NSDictionary *DIGIT_MAPPINGS;
 #else
     defaultRegion = [[NSLocale currentLocale] objectForKey: NSLocaleCountryCode];
 #endif
-    if ([UNKNOWN_REGION_ isEqualToString:defaultRegion]) {
+    if ([NB_UNKNOWN_REGION isEqualToString:defaultRegion]) {
         // get region from device as a failover (e.g. iPad)
         NSLocale *currentLocale = [NSLocale currentLocale];
         defaultRegion = [currentLocale objectForKey:NSLocaleCountryCode];
@@ -3318,7 +3317,7 @@ static NSDictionary *DIGIT_MAPPINGS;
     // The 2nd part of the if is working around an iOS 7 bug
     // If the SIM card is missing, iOS 7 returns an empty string instead of nil
     if (!isoCode || [isoCode isEqualToString:@""]) {
-        isoCode = UNKNOWN_REGION_;
+        isoCode = NB_UNKNOWN_REGION;
     }
     
     return isoCode;
@@ -3664,7 +3663,7 @@ static NSDictionary *DIGIT_MAPPINGS;
         // First see if the first number has an implicit country calling code, by
         // attempting to parse it.
         NSError *anError;
-        firstNumber = [self parse:firstNumberIn defaultRegion:UNKNOWN_REGION_ error:&anError];
+        firstNumber = [self parse:firstNumberIn defaultRegion:NB_UNKNOWN_REGION error:&anError];
         
         if (anError != nil) {
             if ([anError.domain isEqualToString:@"INVALID_COUNTRY_CODE"] == NO) {
@@ -3676,7 +3675,7 @@ static NSDictionary *DIGIT_MAPPINGS;
             // NSN_MATCH.
             if ([secondNumberIn isKindOfClass:[NSString class]] == NO) {
                 NSString *secondNumberRegion = [self getRegionCodeForCountryCode:((NBPhoneNumber*)secondNumberIn).countryCode];
-                if (secondNumberRegion != UNKNOWN_REGION_) {
+                if (secondNumberRegion != NB_UNKNOWN_REGION) {
                     NSError *aNestedError;
                     firstNumber = [self parse:firstNumberIn defaultRegion:secondNumberRegion error:&aNestedError];
                     
@@ -3705,7 +3704,7 @@ static NSDictionary *DIGIT_MAPPINGS;
     
     if ([secondNumberIn isKindOfClass:[NSString class]]) {
         NSError *parseError;
-        secondNumber = [self parse:secondNumberIn defaultRegion:UNKNOWN_REGION_ error:&parseError];
+        secondNumber = [self parse:secondNumberIn defaultRegion:NB_UNKNOWN_REGION error:&parseError];
         if (parseError != nil) {
             if ([parseError.domain isEqualToString:@"INVALID_COUNTRY_CODE"] == NO) {
                 return NBEMatchTypeNOT_A_NUMBER;

--- a/libPhoneNumberTests/NBAsYouTypeFormatterTest1.m
+++ b/libPhoneNumberTests/NBAsYouTypeFormatterTest1.m
@@ -38,7 +38,7 @@
     //testInvalidRegion()
     {
         /** @type {i18n.phonenumbers.AsYouTypeFormatter} */
-        NBAsYouTypeFormatter *f = [[NBAsYouTypeFormatter alloc] initWithRegionCodeForTest:@"ZZ"];
+        NBAsYouTypeFormatter *f = [[NBAsYouTypeFormatter alloc] initWithRegionCodeForTest:NB_UNKNOWN_REGION];
         XCTAssertEqualObjects(@"+", [f inputDigit:@"+"]);
         XCTAssertEqualObjects(@"+4", [f inputDigit:@"4"]);
         XCTAssertEqualObjects(@"+48 ", [f inputDigit:@"8"]);
@@ -62,7 +62,7 @@
     //testInvalidPlusSign()
     {
         /** @type {i18n.phonenumbers.AsYouTypeFormatter} */
-        NBAsYouTypeFormatter *f = [[NBAsYouTypeFormatter alloc] initWithRegionCodeForTest:@"ZZ"];
+        NBAsYouTypeFormatter *f = [[NBAsYouTypeFormatter alloc] initWithRegionCodeForTest:NB_UNKNOWN_REGION];
         XCTAssertEqualObjects(@"+", [f inputDigit:@"+"]);
         XCTAssertEqualObjects(@"+4", [f inputDigit:@"4"]);
         XCTAssertEqualObjects(@"+48 ", [f inputDigit:@"8"]);
@@ -96,7 +96,7 @@
         // The bug occurred last time for countries which have two formatting rules
         // with exactly the same leading digits pattern but differ in length.
         /** @type {i18n.phonenumbers.AsYouTypeFormatter} */
-        NBAsYouTypeFormatter *f = [[NBAsYouTypeFormatter alloc] initWithRegionCodeForTest:@"ZZ"];
+        NBAsYouTypeFormatter *f = [[NBAsYouTypeFormatter alloc] initWithRegionCodeForTest:NB_UNKNOWN_REGION];
         XCTAssertEqualObjects(@"+", [f inputDigit:@"+"]);
         XCTAssertEqualObjects(@"+8", [f inputDigit:@"8"]);
         XCTAssertEqualObjects(@"+81 ", [f inputDigit:@"1"]);

--- a/libPhoneNumberTests/NBPhoneNumberUtilTest1.m
+++ b/libPhoneNumberTests/NBPhoneNumberUtilTest1.m
@@ -1231,17 +1231,17 @@
         XCTAssertTrue([_aUtil isValidNumberForRegion:reNumber regionCode:@"RE"]);
         XCTAssertTrue([_aUtil isValidNumberForRegion:INTERNATIONAL_TOLL_FREE regionCode:@"001"]);
         XCTAssertFalse([_aUtil isValidNumberForRegion:INTERNATIONAL_TOLL_FREE regionCode:@"US"]);
-        XCTAssertFalse([_aUtil isValidNumberForRegion:INTERNATIONAL_TOLL_FREE regionCode:@"ZZ"]);
+        XCTAssertFalse([_aUtil isValidNumberForRegion:INTERNATIONAL_TOLL_FREE regionCode:NB_UNKNOWN_REGION]);
         
         NBPhoneNumber *invalidNumber = [[NBPhoneNumber alloc] init];
         // Invalid country calling codes.
         [invalidNumber setCountryCode:@3923];
         [invalidNumber setNationalNumber:@2366];
-        XCTAssertFalse([_aUtil isValidNumberForRegion:invalidNumber regionCode:@"ZZ"]);
+        XCTAssertFalse([_aUtil isValidNumberForRegion:invalidNumber regionCode:NB_UNKNOWN_REGION]);
         XCTAssertFalse([_aUtil isValidNumberForRegion:invalidNumber regionCode:@"001"]);
         [invalidNumber setCountryCode:0];
         XCTAssertFalse([_aUtil isValidNumberForRegion:invalidNumber regionCode:@"001"]);
-        XCTAssertFalse([_aUtil isValidNumberForRegion:invalidNumber regionCode:@"ZZ"]);
+        XCTAssertFalse([_aUtil isValidNumberForRegion:invalidNumber regionCode:NB_UNKNOWN_REGION]);
     }
 
     
@@ -1320,7 +1320,7 @@
         XCTAssertEqualObjects(@1, [_aUtil getCountryCodeForRegion:@"US"]);
         XCTAssertEqualObjects(@64, [_aUtil getCountryCodeForRegion:@"NZ"]);
         XCTAssertEqualObjects(@0, [_aUtil getCountryCodeForRegion:nil]);
-        XCTAssertEqualObjects(@0, [_aUtil getCountryCodeForRegion:@"ZZ"]);
+        XCTAssertEqualObjects(@0, [_aUtil getCountryCodeForRegion:NB_UNKNOWN_REGION]);
         XCTAssertEqualObjects(@0, [_aUtil getCountryCodeForRegion:@"001"]);
         // CS is already deprecated so the library doesn't support it.
         XCTAssertEqualObjects(@0, [_aUtil getCountryCodeForRegion:@"CS"]);
@@ -1342,7 +1342,7 @@
 
         // Test cases with invalid regions.
         XCTAssertNil([_aUtil getNddPrefixForRegion:nil stripNonDigits:NO]);
-        XCTAssertNil([_aUtil getNddPrefixForRegion:@"ZZ" stripNonDigits:NO]);
+        XCTAssertNil([_aUtil getNddPrefixForRegion:NB_UNKNOWN_REGION stripNonDigits:NO]);
         XCTAssertNil([_aUtil getNddPrefixForRegion:@"001" stripNonDigits:NO]);
 
         // CS is already deprecated so the library doesn't support it.
@@ -1355,7 +1355,7 @@
         XCTAssertTrue([_aUtil isNANPACountry:@"US"]);
         XCTAssertTrue([_aUtil isNANPACountry:@"BS"]);
         XCTAssertFalse([_aUtil isNANPACountry:@"DE"]);
-        XCTAssertFalse([_aUtil isNANPACountry:@"ZZ"]);
+        XCTAssertFalse([_aUtil isNANPACountry:NB_UNKNOWN_REGION]);
         XCTAssertFalse([_aUtil isNANPACountry:@"001"]);
         XCTAssertFalse([_aUtil isNANPACountry:nil]);
     }

--- a/libPhoneNumberTests/NBPhoneNumberUtilTest2.m
+++ b/libPhoneNumberTests/NBPhoneNumberUtilTest2.m
@@ -726,7 +726,7 @@
         {
             NSError *anError = nil;
             NSString *someNumber = @"123 456 7890";
-            [_aUtil parse:someNumber defaultRegion:@"ZZ" error:&anError];
+            [_aUtil parse:someNumber defaultRegion:NB_UNKNOWN_REGION error:&anError];
             if (anError == nil)
                 XCTFail(@"Unknown region code not allowed: should fail.");
             else
@@ -805,7 +805,7 @@
             NSError *anError = nil;
             NSString *emptyNumber = @"";
             // Invalid region.
-            [_aUtil parse:emptyNumber defaultRegion:@"ZZ" error:&anError];
+            [_aUtil parse:emptyNumber defaultRegion:NB_UNKNOWN_REGION error:&anError];
             if (anError == nil)
                 XCTFail(@"Empty string - should fail.");
             else
@@ -816,7 +816,7 @@
         {
             NSError *anError = nil;
             // Invalid region.
-            [_aUtil parse:nil defaultRegion:@"ZZ" error:&anError];
+            [_aUtil parse:nil defaultRegion:NB_UNKNOWN_REGION error:&anError];
             if (anError == nil)
                 XCTFail(@"nil string - should fail.");
             else
@@ -837,7 +837,7 @@
         {
             NSError *anError = nil;
             NSString *domainRfcPhoneContext = @"tel:555-1234;phone-context=www.google.com";
-            [_aUtil parse:domainRfcPhoneContext defaultRegion:@"ZZ" error:&anError];
+            [_aUtil parse:domainRfcPhoneContext defaultRegion:NB_UNKNOWN_REGION error:&anError];
             if (anError == nil)
                 XCTFail(@"Unknown region code not allowed: should fail.");
             else
@@ -851,7 +851,7 @@
             // This should not succeed in being parsed.
             
             NSString *invalidRfcPhoneContext = @"tel:555-1234;phone-context=1-331";
-            [_aUtil parse:invalidRfcPhoneContext defaultRegion:@"ZZ" error:&anError];
+            [_aUtil parse:invalidRfcPhoneContext defaultRegion:NB_UNKNOWN_REGION error:&anError];
             if (anError == nil)
                 XCTFail(@"Unknown region code not allowed: should fail.");
             else
@@ -867,19 +867,19 @@
         NSError *anError;
         // @"ZZ is allowed only if the number starts with a '+' - then the
         // country calling code can be calculated.
-        XCTAssertTrue([NZ_NUMBER isEqual:[_aUtil parse:@"+64 3 331 6005" defaultRegion:@"ZZ" error:&anError]]);
+        XCTAssertTrue([NZ_NUMBER isEqual:[_aUtil parse:@"+64 3 331 6005" defaultRegion:NB_UNKNOWN_REGION error:&anError]]);
         // Test with full-width plus.
-        XCTAssertTrue([NZ_NUMBER isEqual:[_aUtil parse:@"\uFF0B64 3 331 6005" defaultRegion:@"ZZ" error:&anError]]);
+        XCTAssertTrue([NZ_NUMBER isEqual:[_aUtil parse:@"\uFF0B64 3 331 6005" defaultRegion:NB_UNKNOWN_REGION error:&anError]]);
         // Test with normal plus but leading characters that need to be stripped.
-        XCTAssertTrue([NZ_NUMBER isEqual:[_aUtil parse:@"Tel: +64 3 331 6005" defaultRegion:@"ZZ" error:&anError]]);
+        XCTAssertTrue([NZ_NUMBER isEqual:[_aUtil parse:@"Tel: +64 3 331 6005" defaultRegion:NB_UNKNOWN_REGION error:&anError]]);
         XCTAssertTrue([NZ_NUMBER isEqual:[_aUtil parse:@"+64 3 331 6005" defaultRegion:nil error:&anError]]);
         XCTAssertTrue([INTERNATIONAL_TOLL_FREE isEqual:[_aUtil parse:@"+800 1234 5678" defaultRegion:nil error:&anError]]);
         XCTAssertTrue([UNIVERSAL_PREMIUM_RATE isEqual:[_aUtil parse:@"+979 123 456 789" defaultRegion:nil error:&anError]]);
         
         // Test parsing RFC3966 format with a phone context.
-        XCTAssertTrue([NZ_NUMBER isEqual:[_aUtil parse:@"tel:03-331-6005;phone-context=+64" defaultRegion:@"ZZ" error:&anError]]);
-        XCTAssertTrue([NZ_NUMBER isEqual:[_aUtil parse:@"  tel:03-331-6005;phone-context=+64" defaultRegion:@"ZZ" error:&anError]]);
-        XCTAssertTrue([NZ_NUMBER isEqual:[_aUtil parse:@"tel:03-331-6005;isub=12345;phone-context=+64" defaultRegion:@"ZZ" error:&anError]]);
+        XCTAssertTrue([NZ_NUMBER isEqual:[_aUtil parse:@"tel:03-331-6005;phone-context=+64" defaultRegion:NB_UNKNOWN_REGION error:&anError]]);
+        XCTAssertTrue([NZ_NUMBER isEqual:[_aUtil parse:@"  tel:03-331-6005;phone-context=+64" defaultRegion:NB_UNKNOWN_REGION error:&anError]]);
+        XCTAssertTrue([NZ_NUMBER isEqual:[_aUtil parse:@"tel:03-331-6005;isub=12345;phone-context=+64" defaultRegion:NB_UNKNOWN_REGION error:&anError]]);
         
         // It is important that we set the carrier code to an empty string, since we
         // used ParseAndKeepRawInput and no carrier code was found.
@@ -888,7 +888,7 @@
         [nzNumberWithRawInput setRawInput:@"+64 3 331 6005"];
         [nzNumberWithRawInput setCountryCodeSource:[NSNumber numberWithInt:NBECountryCodeSourceFROM_NUMBER_WITH_PLUS_SIGN]];
         [nzNumberWithRawInput setPreferredDomesticCarrierCode:@""];
-        XCTAssertTrue([nzNumberWithRawInput isEqual:[_aUtil parseAndKeepRawInput:@"+64 3 331 6005" defaultRegion:@"ZZ" error:&anError]]);
+        XCTAssertTrue([nzNumberWithRawInput isEqual:[_aUtil parseAndKeepRawInput:@"+64 3 331 6005" defaultRegion:NB_UNKNOWN_REGION error:&anError]]);
         // nil is also allowed for the region code in these cases.
         XCTAssertTrue([nzNumberWithRawInput isEqual:[_aUtil parseAndKeepRawInput:@"+64 3 331 6005" defaultRegion:nil error:&anError]]);
     }
@@ -936,7 +936,7 @@
         XCTAssertTrue([ukNumber isEqual:[_aUtil parse:@"+44 2034567890 x 456  " defaultRegion:@"GB" error:&anError]]);
         XCTAssertTrue([ukNumber isEqual:[_aUtil parse:@"+44 2034567890  X 456" defaultRegion:@"GB" error:&anError]]);
         XCTAssertTrue([ukNumber isEqual:[_aUtil parse:@"+44-2034567890;ext=456" defaultRegion:@"GB" error:&anError]]);
-        XCTAssertTrue([ukNumber isEqual:[_aUtil parse:@"tel:2034567890;ext=456;phone-context=+44" defaultRegion:@"ZZ" error:&anError]]);
+        XCTAssertTrue([ukNumber isEqual:[_aUtil parse:@"tel:2034567890;ext=456;phone-context=+44" defaultRegion:NB_UNKNOWN_REGION error:&anError]]);
         // Full-width extension, @"extn' only.
         XCTAssertTrue([ukNumber isEqual:[_aUtil parse:@"+442034567890\uFF45\uFF58\uFF54\uFF4E456" defaultRegion:@"GB" error:&anError]]);
         // 'xtn' only.


### PR DESCRIPTION
The shared string constants in `NBPhoneNumberDefines.h` were defined as static variables.
As a result, they were not actually shared but instead a new instance was created for
every file that imported the header. This commit changes the constants to use external
linkage which makes them truly shared. On top, the pointers were made immutable. Finally,
the special `@"ZZ"` code for unknown regions was added to the public shared string constants.
Since this code can be returned by a number of public library functions, clients should
have a way to check for it other than using the internal string literal `@"ZZ"`.