### PR TITLE
Master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ DerivedData
 # CocoaPods
 Pods
 ObjectiveC.gcda
+
+*.gcno

--- a/libPhoneNumber/NBMetadataHelper.m
+++ b/libPhoneNumber/NBMetadataHelper.m
@@ -8,6 +8,7 @@
 
 #import "NBMetadataHelper.h"
 #import "NBPhoneMetaData.h"
+#import "NBMetadataCore.h"
 
 
 #if TESTING==1
@@ -46,6 +47,9 @@ static NSMutableDictionary *kMapCCode2CN = nil;
  */
 - (void)initializeHelper
 {
+	if (!NBPhoneMetadataAM.class) // force linkage of NBMetadataCore.m
+		return;
+
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         kMapCCode2CN = [NSMutableDictionary dictionaryWithObjectsAndKeys:


### PR DESCRIPTION
Forced linkage of NBMetadataCore.m: useful (actually even necessary) when linking the lib files statically, or linking against a
static libPhoneNumber