### PR TITLE
Enable Formatting of Obfuscated Numbers

### DIFF
--- a/libPhoneNumber/NBPhoneNumberDefines.m
+++ b/libPhoneNumber/NBPhoneNumberDefines.m
@@ -3,5 +3,5 @@
 NSString * const NB_UNKNOWN_REGION = @"ZZ";
 NSString * const NB_NON_BREAKING_SPACE = @"\u00a0";
 NSString * const NB_PLUS_CHARS = @"+＋";
-NSString * const NB_VALID_DIGITS_STRING = @"0-9０-９٠-٩۰-۹";
+NSString * const NB_VALID_DIGITS_STRING = @"0-9０-９٠-٩۰-۹ *";
 NSString * const NB_REGION_CODE_FOR_NON_GEO_ENTITY = @"001";

--- a/libPhoneNumber/NBPhoneNumberUtil.m
+++ b/libPhoneNumber/NBPhoneNumberUtil.m
@@ -470,7 +470,7 @@ static NSArray *GEO_MOBILE_COUNTRIES;
 {
     if (!DIGIT_MAPPINGS) {
         DIGIT_MAPPINGS = [NSDictionary dictionaryWithObjectsAndKeys:
-                          @"0", @"0", @"1", @"1", @"2", @"2", @"3", @"3", @"4", @"4", @"5", @"5", @"6", @"6", @"7", @"7", @"8", @"8", @"9", @"9",
+                          @"0", @"0", @"1", @"1", @"2", @"2", @"3", @"3", @"4", @"4", @"5", @"5", @"6", @"6", @"7", @"7", @"8", @"8", @"9", @"9", @"*", @"\*",
                           // Fullwidth digit 0 to 9
                           @"0", @"\uFF10", @"1", @"\uFF11", @"2", @"\uFF12", @"3", @"\uFF13", @"4", @"\uFF14", @"5", @"\uFF15", @"6", @"\uFF16", @"7", @"\uFF17", @"8", @"\uFF18", @"9", @"\uFF19",
                           // Arabic-indic digit 0 to 9


### PR DESCRIPTION
A project I am working on requires that numbers be obfuscated with the asterisk `*` but the formatting did not work anymore. This change will recognize the asterisk as a character in string so that it will still format accordingly. 

Example: (123) 456-7890 -> (***) **6-7890