### PR TITLE
Add tvOS support, watchOS and tvOS Xcode targets

### DIFF
--- a/libPhoneNumber-iOS.podspec
+++ b/libPhoneNumber-iOS.podspec
@@ -14,6 +14,7 @@ DESC
   s.ios.deployment_target = "6.0"
   s.osx.deployment_target = "10.9"
   s.watchos.deployment_target = "2.0"
+  s.tvos.deployment_target = "9.0"
   s.requires_arc = true
   s.source_files = 'libPhoneNumber/NBPhoneNumberDefines.{h,m}', 'libPhoneNumber/NBPhoneNumber.{h,m}', 'libPhoneNumber/NBNumberFormat.{h,m}', 'libPhoneNumber/NBPhoneNumberDesc.{h,m}', 'libPhoneNumber/NBPhoneMetaData.{h,m}', 'libPhoneNumber/NBPhoneNumberUtil.{h,m}', 'libPhoneNumber/NBMetadataHelper.{h,m}', 'libPhoneNumber/NBAsYouTypeFormatter.{h,m}', 'libPhoneNumber/NBMetadataCore.{h,m}', 'libPhoneNumber/NBMetadataCoreTest.{h,m}', 'libPhoneNumber/NBMetadataCoreMapper.{h,m}', 'libPhoneNumber/NBMetadataCoreTestMapper.{h,m}'
 end

--- a/libPhoneNumber-tvOS/Info.plist
+++ b/libPhoneNumber-tvOS/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/libPhoneNumber-tvOS/libPhoneNumber-tvOS.h
+++ b/libPhoneNumber-tvOS/libPhoneNumber-tvOS.h
@@ -1,0 +1,35 @@
+//
+//  libPhoneNumber-tvOS.h
+//  libPhoneNumber-tvOS
+//
+//  Created by Jeff Kelley on 11/16/16.
+//  Copyright © 2016 ohtalk.me. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+//! Project version number for libPhoneNumber-tvOS.
+FOUNDATION_EXPORT double libPhoneNumber_tvOSVersionNumber;
+
+//! Project version string for libPhoneNumber-tvOS.
+FOUNDATION_EXPORT const unsigned char libPhoneNumber_tvOSVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <libPhoneNumber_tvOS/PublicHeader.h>
+
+
+#import "NBPhoneNumberDefines.h"
+
+// Features
+#import "NBPhoneNumberUtil.h"
+#import "NBAsYouTypeFormatter.h"
+
+// Metadata
+#import "NBMetadataCore.h"
+#import "NBMetadataCoreMapper.h"
+#import "NBMetadataHelper.h"
+
+// Model
+#import "NBPhoneMetaData.h"
+#import "NBNumberFormat.h"
+#import "NBPhoneNumber.h"
+#import "NBPhoneNumberDesc.h"

--- a/libPhoneNumber-watchOS/Info.plist
+++ b/libPhoneNumber-watchOS/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/libPhoneNumber-watchOS/libPhoneNumber-watchOS.h
+++ b/libPhoneNumber-watchOS/libPhoneNumber-watchOS.h
@@ -1,0 +1,35 @@
+//
+//  libPhoneNumber-watchOS.h
+//  libPhoneNumber-watchOS
+//
+//  Created by Jeff Kelley on 11/16/16.
+//  Copyright © 2016 ohtalk.me. All rights reserved.
+//
+
+#import <WatchKit/WatchKit.h>
+
+//! Project version number for libPhoneNumber-watchOS.
+FOUNDATION_EXPORT double libPhoneNumber_watchOSVersionNumber;
+
+//! Project version string for libPhoneNumber-watchOS.
+FOUNDATION_EXPORT const unsigned char libPhoneNumber_watchOSVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <libPhoneNumber_watchOS/PublicHeader.h>
+
+
+#import "NBPhoneNumberDefines.h"
+
+// Features
+#import "NBPhoneNumberUtil.h"
+#import "NBAsYouTypeFormatter.h"
+
+// Metadata
+#import "NBMetadataCore.h"
+#import "NBMetadataCoreMapper.h"
+#import "NBMetadataHelper.h"
+
+// Model
+#import "NBPhoneMetaData.h"
+#import "NBNumberFormat.h"
+#import "NBPhoneNumber.h"
+#import "NBPhoneNumberDesc.h"

--- a/libPhoneNumber.xcodeproj/project.pbxproj
+++ b/libPhoneNumber.xcodeproj/project.pbxproj
@@ -13,6 +13,48 @@
 		145402041DAAF91A00EB1F7C /* NBAsYouTypeFormatterTest2.m in Sources */ = {isa = PBXBuildFile; fileRef = FDE51FA01B6FD26C002D9798 /* NBAsYouTypeFormatterTest2.m */; };
 		187A618E1A25DF04000D8BB6 /* PhoneNumberMetaData.json in Resources */ = {isa = PBXBuildFile; fileRef = 187A618A1A25DF04000D8BB6 /* PhoneNumberMetaData.json */; };
 		187A618F1A25DF04000D8BB6 /* PhoneNumberMetaDataForTesting.json in Resources */ = {isa = PBXBuildFile; fileRef = 187A618B1A25DF04000D8BB6 /* PhoneNumberMetaDataForTesting.json */; };
+		1F31D52E1DDD46B100257818 /* libPhoneNumber-watchOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F31D52C1DDD46B100257818 /* libPhoneNumber-watchOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1F31D5321DDD46B900257818 /* NBMetadataHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = FD12C2681A87401B00B53856 /* NBMetadataHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1F31D5331DDD46BD00257818 /* NBMetadataHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = FD12C2691A87401B00B53856 /* NBMetadataHelper.m */; };
+		1F31D5341DDD46BF00257818 /* NBMetadataCore.h in Headers */ = {isa = PBXBuildFile; fileRef = FD12C26C1A87546400B53856 /* NBMetadataCore.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1F31D5351DDD46D200257818 /* NBMetadataCore.m in Sources */ = {isa = PBXBuildFile; fileRef = FD12C26D1A87546400B53856 /* NBMetadataCore.m */; };
+		1F31D5361DDD46D700257818 /* NBMetadataCoreMapper.h in Headers */ = {isa = PBXBuildFile; fileRef = FDBCFA0A1A87AD8C00297F21 /* NBMetadataCoreMapper.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1F31D5371DDD46DA00257818 /* NBMetadataCoreMapper.m in Sources */ = {isa = PBXBuildFile; fileRef = FDBCFA0B1A87AD8C00297F21 /* NBMetadataCoreMapper.m */; };
+		1F31D5391DDD46E600257818 /* NBPhoneNumberDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = FD8B842E1934C35F00C350EB /* NBPhoneNumberDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1F31D53A1DDD46EA00257818 /* NBPhoneNumberDefines.m in Sources */ = {isa = PBXBuildFile; fileRef = A81D6A281BECC43A00F68F34 /* NBPhoneNumberDefines.m */; };
+		1F31D53B1DDD46ED00257818 /* NBPhoneNumberUtil.h in Headers */ = {isa = PBXBuildFile; fileRef = FD8B84311934C35F00C350EB /* NBPhoneNumberUtil.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1F31D53C1DDD46F000257818 /* NBPhoneNumberUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = FD8B84321934C35F00C350EB /* NBPhoneNumberUtil.m */; };
+		1F31D53D1DDD46F300257818 /* NBAsYouTypeFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = FD8B84261934C35F00C350EB /* NBAsYouTypeFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1F31D53E1DDD46F700257818 /* NBAsYouTypeFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = FD8B84271934C35F00C350EB /* NBAsYouTypeFormatter.m */; };
+		1F31D5401DDD477300257818 /* NBPhoneNumber.h in Headers */ = {isa = PBXBuildFile; fileRef = FD8B842C1934C35F00C350EB /* NBPhoneNumber.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1F31D5411DDD477600257818 /* NBPhoneNumber.m in Sources */ = {isa = PBXBuildFile; fileRef = FD8B842D1934C35F00C350EB /* NBPhoneNumber.m */; };
+		1F31D5421DDD477800257818 /* NBNumberFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = FD8B84281934C35F00C350EB /* NBNumberFormat.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1F31D5431DDD477B00257818 /* NBNumberFormat.m in Sources */ = {isa = PBXBuildFile; fileRef = FD8B84291934C35F00C350EB /* NBNumberFormat.m */; };
+		1F31D5441DDD477D00257818 /* NBPhoneNumberDesc.h in Headers */ = {isa = PBXBuildFile; fileRef = FD8B842F1934C35F00C350EB /* NBPhoneNumberDesc.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1F31D5451DDD478100257818 /* NBPhoneNumberDesc.m in Sources */ = {isa = PBXBuildFile; fileRef = FD8B84301934C35F00C350EB /* NBPhoneNumberDesc.m */; };
+		1F31D5461DDD478300257818 /* NBPhoneMetaData.h in Headers */ = {isa = PBXBuildFile; fileRef = FD8B842A1934C35F00C350EB /* NBPhoneMetaData.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1F31D5471DDD478600257818 /* NBPhoneMetaData.m in Sources */ = {isa = PBXBuildFile; fileRef = FD8B842B1934C35F00C350EB /* NBPhoneMetaData.m */; };
+		1F31D5511DDD47BA00257818 /* libPhoneNumber-tvOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F31D54F1DDD47BA00257818 /* libPhoneNumber-tvOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1F31D5551DDD47EB00257818 /* NBMetadataHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = FD12C2681A87401B00B53856 /* NBMetadataHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1F31D5561DDD47F000257818 /* NBMetadataHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = FD12C2691A87401B00B53856 /* NBMetadataHelper.m */; };
+		1F31D5571DDD47F300257818 /* NBMetadataCore.h in Headers */ = {isa = PBXBuildFile; fileRef = FD12C26C1A87546400B53856 /* NBMetadataCore.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1F31D5581DDD47F700257818 /* NBMetadataCore.m in Sources */ = {isa = PBXBuildFile; fileRef = FD12C26D1A87546400B53856 /* NBMetadataCore.m */; };
+		1F31D5591DDD47FE00257818 /* NBMetadataCoreMapper.h in Headers */ = {isa = PBXBuildFile; fileRef = FDBCFA0A1A87AD8C00297F21 /* NBMetadataCoreMapper.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1F31D55A1DDD480200257818 /* NBMetadataCoreMapper.m in Sources */ = {isa = PBXBuildFile; fileRef = FDBCFA0B1A87AD8C00297F21 /* NBMetadataCoreMapper.m */; };
+		1F31D55C1DDD481B00257818 /* NBPhoneNumber.h in Headers */ = {isa = PBXBuildFile; fileRef = FD8B842C1934C35F00C350EB /* NBPhoneNumber.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1F31D55D1DDD481D00257818 /* NBPhoneNumber.m in Sources */ = {isa = PBXBuildFile; fileRef = FD8B842D1934C35F00C350EB /* NBPhoneNumber.m */; };
+		1F31D55E1DDD482000257818 /* NBNumberFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = FD8B84281934C35F00C350EB /* NBNumberFormat.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1F31D55F1DDD482300257818 /* NBNumberFormat.m in Sources */ = {isa = PBXBuildFile; fileRef = FD8B84291934C35F00C350EB /* NBNumberFormat.m */; };
+		1F31D5601DDD482600257818 /* NBPhoneNumberDesc.h in Headers */ = {isa = PBXBuildFile; fileRef = FD8B842F1934C35F00C350EB /* NBPhoneNumberDesc.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1F31D5611DDD482900257818 /* NBPhoneNumberDesc.m in Sources */ = {isa = PBXBuildFile; fileRef = FD8B84301934C35F00C350EB /* NBPhoneNumberDesc.m */; };
+		1F31D5621DDD482C00257818 /* NBPhoneMetaData.h in Headers */ = {isa = PBXBuildFile; fileRef = FD8B842A1934C35F00C350EB /* NBPhoneMetaData.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1F31D5631DDD482F00257818 /* NBPhoneMetaData.m in Sources */ = {isa = PBXBuildFile; fileRef = FD8B842B1934C35F00C350EB /* NBPhoneMetaData.m */; };
+		1F31D5641DDD483200257818 /* NBPhoneNumberDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = FD8B842E1934C35F00C350EB /* NBPhoneNumberDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1F31D5651DDD483500257818 /* NBPhoneNumberDefines.m in Sources */ = {isa = PBXBuildFile; fileRef = A81D6A281BECC43A00F68F34 /* NBPhoneNumberDefines.m */; };
+		1F31D5661DDD483700257818 /* NBPhoneNumberUtil.h in Headers */ = {isa = PBXBuildFile; fileRef = FD8B84311934C35F00C350EB /* NBPhoneNumberUtil.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1F31D5671DDD483A00257818 /* NBPhoneNumberUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = FD8B84321934C35F00C350EB /* NBPhoneNumberUtil.m */; };
+		1F31D5681DDD483C00257818 /* NBAsYouTypeFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = FD8B84261934C35F00C350EB /* NBAsYouTypeFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1F31D5691DDD484000257818 /* NBAsYouTypeFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = FD8B84271934C35F00C350EB /* NBAsYouTypeFormatter.m */; };
 		29F3A15D17B98AE1005D8E07 /* CoreTelephony.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 29F3A15C17B98AE1005D8E07 /* CoreTelephony.framework */; };
 		29F3A15E17B98B3C005D8E07 /* CoreTelephony.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 29F3A15C17B98AE1005D8E07 /* CoreTelephony.framework */; };
 		34ACBB8A1B7122AC0064B3BD /* libPhoneNumber.h in Headers */ = {isa = PBXBuildFile; fileRef = 34ACBB891B7122AC0064B3BD /* libPhoneNumber.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -102,6 +144,12 @@
 /* Begin PBXFileReference section */
 		187A618A1A25DF04000D8BB6 /* PhoneNumberMetaData.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = PhoneNumberMetaData.json; path = libPhoneNumberTests/generatedJSON/PhoneNumberMetaData.json; sourceTree = SOURCE_ROOT; };
 		187A618B1A25DF04000D8BB6 /* PhoneNumberMetaDataForTesting.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = PhoneNumberMetaDataForTesting.json; path = libPhoneNumberTests/generatedJSON/PhoneNumberMetaDataForTesting.json; sourceTree = SOURCE_ROOT; };
+		1F31D52A1DDD46B100257818 /* libPhoneNumber.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = libPhoneNumber.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		1F31D52C1DDD46B100257818 /* libPhoneNumber-watchOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "libPhoneNumber-watchOS.h"; sourceTree = "<group>"; };
+		1F31D52D1DDD46B100257818 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		1F31D54D1DDD47B900257818 /* libPhoneNumber.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = libPhoneNumber.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		1F31D54F1DDD47BA00257818 /* libPhoneNumber-tvOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "libPhoneNumber-tvOS.h"; sourceTree = "<group>"; };
+		1F31D5501DDD47BA00257818 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		29F3A15C17B98AE1005D8E07 /* CoreTelephony.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreTelephony.framework; path = System/Library/Frameworks/CoreTelephony.framework; sourceTree = SDKROOT; };
 		34ACBB851B7122AC0064B3BD /* libPhoneNumber.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = libPhoneNumber.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		34ACBB881B7122AC0064B3BD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -169,6 +217,20 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		1F31D5261DDD46B100257818 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1F31D5491DDD47B900257818 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		34ACBB811B7122AC0064B3BD /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -212,6 +274,24 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		1F31D52B1DDD46B100257818 /* libPhoneNumber-watchOS */ = {
+			isa = PBXGroup;
+			children = (
+				1F31D52C1DDD46B100257818 /* libPhoneNumber-watchOS.h */,
+				1F31D52D1DDD46B100257818 /* Info.plist */,
+			);
+			path = "libPhoneNumber-watchOS";
+			sourceTree = "<group>";
+		};
+		1F31D54E1DDD47BA00257818 /* libPhoneNumber-tvOS */ = {
+			isa = PBXGroup;
+			children = (
+				1F31D54F1DDD47BA00257818 /* libPhoneNumber-tvOS.h */,
+				1F31D5501DDD47BA00257818 /* Info.plist */,
+			);
+			path = "libPhoneNumber-tvOS";
+			sourceTree = "<group>";
+		};
 		34ACBB861B7122AC0064B3BD /* libPhoneNumber (Framework) */ = {
 			isa = PBXGroup;
 			children = (
@@ -282,6 +362,8 @@
 				FD7A0626167715A0004BBEB6 /* libPhoneNumber */,
 				FD6AE8F71BEE72B600263DE1 /* libPhoneNumber-SwiftDemo */,
 				FD7A0644167715A1004BBEB6 /* libPhoneNumber UnitTest */,
+				1F31D52B1DDD46B100257818 /* libPhoneNumber-watchOS */,
+				1F31D54E1DDD47BA00257818 /* libPhoneNumber-tvOS */,
 				FD7A061F167715A0004BBEB6 /* Frameworks */,
 				FD7A061D167715A0004BBEB6 /* Products */,
 			);
@@ -294,6 +376,8 @@
 				FD7A063D167715A1004BBEB6 /* libPhoneNumberTests.xctest */,
 				34ACBB851B7122AC0064B3BD /* libPhoneNumber.framework */,
 				FD6AE8F61BEE72B600263DE1 /* libPhoneNumberSampleSwift.app */,
+				1F31D52A1DDD46B100257818 /* libPhoneNumber.framework */,
+				1F31D54D1DDD47B900257818 /* libPhoneNumber.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -385,6 +469,42 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		1F31D5271DDD46B100257818 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1F31D5461DDD478300257818 /* NBPhoneMetaData.h in Headers */,
+				1F31D5401DDD477300257818 /* NBPhoneNumber.h in Headers */,
+				1F31D5421DDD477800257818 /* NBNumberFormat.h in Headers */,
+				1F31D53B1DDD46ED00257818 /* NBPhoneNumberUtil.h in Headers */,
+				1F31D52E1DDD46B100257818 /* libPhoneNumber-watchOS.h in Headers */,
+				1F31D53D1DDD46F300257818 /* NBAsYouTypeFormatter.h in Headers */,
+				1F31D5321DDD46B900257818 /* NBMetadataHelper.h in Headers */,
+				1F31D5341DDD46BF00257818 /* NBMetadataCore.h in Headers */,
+				1F31D5391DDD46E600257818 /* NBPhoneNumberDefines.h in Headers */,
+				1F31D5361DDD46D700257818 /* NBMetadataCoreMapper.h in Headers */,
+				1F31D5441DDD477D00257818 /* NBPhoneNumberDesc.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1F31D54A1DDD47B900257818 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1F31D5511DDD47BA00257818 /* libPhoneNumber-tvOS.h in Headers */,
+				1F31D5551DDD47EB00257818 /* NBMetadataHelper.h in Headers */,
+				1F31D5621DDD482C00257818 /* NBPhoneMetaData.h in Headers */,
+				1F31D5601DDD482600257818 /* NBPhoneNumberDesc.h in Headers */,
+				1F31D5661DDD483700257818 /* NBPhoneNumberUtil.h in Headers */,
+				1F31D5571DDD47F300257818 /* NBMetadataCore.h in Headers */,
+				1F31D5591DDD47FE00257818 /* NBMetadataCoreMapper.h in Headers */,
+				1F31D5681DDD483C00257818 /* NBAsYouTypeFormatter.h in Headers */,
+				1F31D55E1DDD482000257818 /* NBNumberFormat.h in Headers */,
+				1F31D5641DDD483200257818 /* NBPhoneNumberDefines.h in Headers */,
+				1F31D55C1DDD481B00257818 /* NBPhoneNumber.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		34ACBB821B7122AC0064B3BD /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -406,6 +526,42 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		1F31D5291DDD46B100257818 /* libPhoneNumber-watchOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1F31D5311DDD46B100257818 /* Build configuration list for PBXNativeTarget "libPhoneNumber-watchOS" */;
+			buildPhases = (
+				1F31D5251DDD46B100257818 /* Sources */,
+				1F31D5261DDD46B100257818 /* Frameworks */,
+				1F31D5271DDD46B100257818 /* Headers */,
+				1F31D5281DDD46B100257818 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "libPhoneNumber-watchOS";
+			productName = "libPhoneNumber-watchOS";
+			productReference = 1F31D52A1DDD46B100257818 /* libPhoneNumber.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		1F31D54C1DDD47B900257818 /* libPhoneNumber-tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1F31D5521DDD47BA00257818 /* Build configuration list for PBXNativeTarget "libPhoneNumber-tvOS" */;
+			buildPhases = (
+				1F31D5481DDD47B900257818 /* Sources */,
+				1F31D5491DDD47B900257818 /* Frameworks */,
+				1F31D54A1DDD47B900257818 /* Headers */,
+				1F31D54B1DDD47B900257818 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "libPhoneNumber-tvOS";
+			productName = "libPhoneNumber-tvOS";
+			productReference = 1F31D54D1DDD47B900257818 /* libPhoneNumber.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		34ACBB841B7122AC0064B3BD /* libPhoneNumber-iOS */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 34ACBBA21B7122AC0064B3BD /* Build configuration list for PBXNativeTarget "libPhoneNumber-iOS" */;
@@ -489,6 +645,14 @@
 				LastUpgradeCheck = 0710;
 				ORGANIZATIONNAME = ohtalk.me;
 				TargetAttributes = {
+					1F31D5291DDD46B100257818 = {
+						CreatedOnToolsVersion = 8.1;
+						ProvisioningStyle = Automatic;
+					};
+					1F31D54C1DDD47B900257818 = {
+						CreatedOnToolsVersion = 8.1;
+						ProvisioningStyle = Automatic;
+					};
 					34ACBB841B7122AC0064B3BD = {
 						CreatedOnToolsVersion = 6.4;
 					};
@@ -515,11 +679,27 @@
 				FD7A061B167715A0004BBEB6 /* libPhoneNumberSampleObjectiveC */,
 				34ACBB841B7122AC0064B3BD /* libPhoneNumber-iOS */,
 				FD7A063C167715A1004BBEB6 /* libPhoneNumberTests */,
+				1F31D5291DDD46B100257818 /* libPhoneNumber-watchOS */,
+				1F31D54C1DDD47B900257818 /* libPhoneNumber-tvOS */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		1F31D5281DDD46B100257818 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1F31D54B1DDD47B900257818 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		34ACBB831B7122AC0064B3BD /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -561,6 +741,40 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		1F31D5251DDD46B100257818 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1F31D5331DDD46BD00257818 /* NBMetadataHelper.m in Sources */,
+				1F31D5371DDD46DA00257818 /* NBMetadataCoreMapper.m in Sources */,
+				1F31D53E1DDD46F700257818 /* NBAsYouTypeFormatter.m in Sources */,
+				1F31D5451DDD478100257818 /* NBPhoneNumberDesc.m in Sources */,
+				1F31D53C1DDD46F000257818 /* NBPhoneNumberUtil.m in Sources */,
+				1F31D5431DDD477B00257818 /* NBNumberFormat.m in Sources */,
+				1F31D5471DDD478600257818 /* NBPhoneMetaData.m in Sources */,
+				1F31D5411DDD477600257818 /* NBPhoneNumber.m in Sources */,
+				1F31D53A1DDD46EA00257818 /* NBPhoneNumberDefines.m in Sources */,
+				1F31D5351DDD46D200257818 /* NBMetadataCore.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1F31D5481DDD47B900257818 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1F31D5631DDD482F00257818 /* NBPhoneMetaData.m in Sources */,
+				1F31D5611DDD482900257818 /* NBPhoneNumberDesc.m in Sources */,
+				1F31D5651DDD483500257818 /* NBPhoneNumberDefines.m in Sources */,
+				1F31D5561DDD47F000257818 /* NBMetadataHelper.m in Sources */,
+				1F31D55D1DDD481D00257818 /* NBPhoneNumber.m in Sources */,
+				1F31D55A1DDD480200257818 /* NBMetadataCoreMapper.m in Sources */,
+				1F31D5691DDD484000257818 /* NBAsYouTypeFormatter.m in Sources */,
+				1F31D5671DDD483A00257818 /* NBPhoneNumberUtil.m in Sources */,
+				1F31D55F1DDD482300257818 /* NBNumberFormat.m in Sources */,
+				1F31D5581DDD47F700257818 /* NBMetadataCore.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		34ACBB801B7122AC0064B3BD /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -678,6 +892,188 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		1F31D52F1DDD46B100257818 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = "libPhoneNumber-watchOS/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = me.ohtalk.libPhoneNumberFramework;
+				PRODUCT_NAME = libPhoneNumber;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+				WATCHOS_DEPLOYMENT_TARGET = 3.1;
+			};
+			name = Debug;
+		};
+		1F31D5301DDD46B100257818 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CODE_SIGN_IDENTITY = "";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = "libPhoneNumber-watchOS/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = me.ohtalk.libPhoneNumberFramework;
+				PRODUCT_NAME = libPhoneNumber;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+				WATCHOS_DEPLOYMENT_TARGET = 3.1;
+			};
+			name = Release;
+		};
+		1F31D5531DDD47BA00257818 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = "libPhoneNumber-tvOS/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = me.ohtalk.libPhoneNumberFramework;
+				PRODUCT_NAME = libPhoneNumber;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 10.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		1F31D5541DDD47BA00257818 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CODE_SIGN_IDENTITY = "";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = "libPhoneNumber-tvOS/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = me.ohtalk.libPhoneNumberFramework;
+				PRODUCT_NAME = libPhoneNumber;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 10.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
 		34ACBB9E1B7122AC0064B3BD /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -998,6 +1394,22 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		1F31D5311DDD46B100257818 /* Build configuration list for PBXNativeTarget "libPhoneNumber-watchOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1F31D52F1DDD46B100257818 /* Debug */,
+				1F31D5301DDD46B100257818 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		1F31D5521DDD47BA00257818 /* Build configuration list for PBXNativeTarget "libPhoneNumber-tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1F31D5531DDD47BA00257818 /* Debug */,
+				1F31D5541DDD47BA00257818 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
 		34ACBBA21B7122AC0064B3BD /* Build configuration list for PBXNativeTarget "libPhoneNumber-iOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/libPhoneNumber/NBPhoneNumberUtil.h
+++ b/libPhoneNumber/NBPhoneNumberUtil.h
@@ -32,7 +32,7 @@
 
 - (NSString*)extractPossibleNumber:(NSString*)phoneNumber;
 - (NSNumber*)extractCountryCode:(NSString*)fullNumber nationalNumber:(NSString**)nationalNumber;
-#if TARGET_OS_IPHONE && !TARGET_OS_WATCH
+#if TARGET_OS_IOS
 - (NSString *)countryCodeByCarrier;
 #endif
 

--- a/libPhoneNumber/NBPhoneNumberUtil.m
+++ b/libPhoneNumber/NBPhoneNumberUtil.m
@@ -15,7 +15,7 @@
 #import "NBMetadataHelper.h"
 #import <math.h>
 
-#if TARGET_OS_IPHONE && !TARGET_OS_WATCH
+#if TARGET_OS_IOS
 #import <CoreTelephony/CTTelephonyNetworkInfo.h>
 #import <CoreTelephony/CTCarrier.h>
 #endif
@@ -39,7 +39,7 @@
 @property (nonatomic, strong) NSRegularExpression *CAPTURING_DIGIT_PATTERN;
 @property (nonatomic, strong) NSRegularExpression *VALID_ALPHA_PHONE_PATTERN;
 
-#if TARGET_OS_IPHONE && !TARGET_OS_WATCH
+#if TARGET_OS_IOS
 @property (nonatomic, readonly) CTTelephonyNetworkInfo *telephonyNetworkInfo;
 #endif
 
@@ -3276,7 +3276,7 @@ static NSArray *GEO_MOBILE_COUNTRIES;
     numberToParse = [helper normalizeNonBreakingSpace:numberToParse];
     
     NSString *defaultRegion = nil;
-#if TARGET_OS_IPHONE && !TARGET_OS_WATCH
+#if TARGET_OS_IOS
     defaultRegion = [self countryCodeByCarrier];
 #else
     defaultRegion = [[NSLocale currentLocale] objectForKey: NSLocaleCountryCode];
@@ -3290,7 +3290,7 @@ static NSArray *GEO_MOBILE_COUNTRIES;
     return [self parse:numberToParse defaultRegion:defaultRegion error:error];
 }
 
-#if TARGET_OS_IPHONE && !TARGET_OS_WATCH
+#if TARGET_OS_IOS
 
 static CTTelephonyNetworkInfo* _telephonyNetworkInfo;
 


### PR DESCRIPTION
This PR mostly gets tvOS support into libPhoneNumber. To do so, I had to change imports from `#if TARGET_OS_IPHONE && !TARGET_OS_WATCH` to `#if TARGET_OS_IOS`, as `TARGET_OS_IPHONE` is `1` on tvOS. You could keep backwards compatibility with older versions of Xcode by changing it to `#if TARGET_OS_IPHONE && !TARGET_OS_WATCH && !TARGET_OS_TV` but that seemed a bit unwieldy to me.

I also added Xcode targets to build watchOS and tvOS frameworks locally.