### PR TITLE
Port normalizeDiallableCharsOnly to Objective C

### DIFF
--- a/libPhoneNumber/NBPhoneNumberUtil.h
+++ b/libPhoneNumber/NBPhoneNumberUtil.h
@@ -27,6 +27,7 @@
 
 - (NSString*)normalize:(NSString*)phoneNumber;
 - (NSString*)normalizeDigitsOnly:(NSString*)number;
+- (NSString*)normalizeDiallableCharsOnly:(NSString*)number;
 
 - (BOOL)isNumberGeographical:(NBPhoneNumber*)phoneNumber;
 

--- a/libPhoneNumber/NBPhoneNumberUtil.m
+++ b/libPhoneNumber/NBPhoneNumberUtil.m
@@ -491,7 +491,7 @@ static NSArray *GEO_MOBILE_COUNTRIES;
     if (!DIALLABLE_CHAR_MAPPINGS) {
         DIALLABLE_CHAR_MAPPINGS = [NSDictionary dictionaryWithObjectsAndKeys:
                                    @"0", @"0", @"1", @"1", @"2", @"2", @"3", @"3", @"4", @"4", @"5", @"5", @"6", @"6", @"7", @"7", @"8", @"8", @"9", @"9",
-                                   @"+", @"+", @"*", @"*", nil];
+                                   @"+", @"+", @"*", @"*", @"#", @"#", nil];
     }
     
     if (!ALPHA_MAPPINGS) {
@@ -674,7 +674,7 @@ static NSArray *GEO_MOBILE_COUNTRIES;
 }
 
 
-/**
+/**
   * Normalizes a string of characters representing a phone number. This strips
   * all characters which are not diallable on a mobile phone keypad (including
   * all non-ASCII digits).
@@ -687,7 +687,7 @@ static NSArray *GEO_MOBILE_COUNTRIES;
   NBMetadataHelper *helper = [[NBMetadataHelper alloc] init];
   number = [helper normalizeNonBreakingSpace:number];
 
-  return [self stringByReplacingOccurrencesString:number withMap:self.DIALLABLE_CHAR_MAPPINGS removeNonMatches:YES];
+  return [self stringByReplacingOccurrencesString:number withMap:DIALLABLE_CHAR_MAPPINGS removeNonMatches:YES];
 }
 
 

--- a/libPhoneNumber/NBPhoneNumberUtil.m
+++ b/libPhoneNumber/NBPhoneNumberUtil.m
@@ -674,6 +674,23 @@ static NSArray *GEO_MOBILE_COUNTRIES;
 }
 
 
+/**
+  * Normalizes a string of characters representing a phone number. This strips
+  * all characters which are not diallable on a mobile phone keypad (including
+  * all non-ASCII digits).
+  *
+  * - param {string} number a string of characters representing a phone number.
+  * @return {string} the normalized string version of the phone number.
+  */
+- (NSString*)normalizeDiallableCharsOnly:(NSString*)number
+{
+  NBMetadataHelper *helper = [[NBMetadataHelper alloc] init];
+  number = [helper normalizeNonBreakingSpace:number];
+
+  return [self stringByReplacingOccurrencesString:number withMap:self.DIALLABLE_CHAR_MAPPINGS removeNonMatches:YES];
+}
+
+
 /**
  * Converts all alpha characters in a number to their respective digits on a
  * keypad, but retains existing formatting. Also converts wide-ascii digits to

--- a/libPhoneNumberTests/NBPhoneNumberUtilTest1.m
+++ b/libPhoneNumberTests/NBPhoneNumberUtilTest1.m
@@ -550,6 +550,14 @@
     }
 
     
+    #pragma mark - testNormalizeStripNonDiallableCharacters
+    {
+        NSString *inputNumber = @"03*4-56&+1a#234";
+        NSString *expectedOutput = @"03*456+1#234";
+        XCTAssertEqualObjects(expectedOutput, [_aUtil normalizeDiallableCharsOnly:inputNumber], @"Conversion did not correctly remove non-diallable characters");
+    }
+
+    
     #pragma mark - testFormatUSNumber
     {
         XCTAssertEqualObjects(@"650 253 0000", [_aUtil format:US_NUMBER numberFormat:NBEPhoneNumberFormatNATIONAL]);


### PR DESCRIPTION
Parallel of https://github.com/googlei18n/libphonenumber/pull/1526. 
Also added '#' to DIALLABLE_CHAR_MAPPINGS, since it's in there for Java/JS libPhoneNumber.

The objc port seems to use a mix of 
`NBPhoneNumberUtil-normalizeHelper:normalizationReplacements:removeNonMatches:`
and 
`NSString-stringByReplacingOccurrencesString:withMap:removeNonMatches:`
so I wasn't sure if I should extend the call to other methods that use DIALLABLE_CHAR_MAPPINGS.