### PR TITLE
California area code 310 validation fix

### DIFF
--- a/libPhoneNumber/NBMetadataCore.m
+++ b/libPhoneNumber/NBMetadataCore.m
@@ -14622,12 +14622,12 @@
 
         NSMutableArray *fixedLine_descArrayPL = [[NSMutableArray alloc] init];
         [fixedLine_descArrayPL addObject: [NSNumber numberWithInt:10]];
-        self.fixedLine = [[NBPhoneNumberDesc alloc] initWithNationalNumberPattern:@"(?:2(?:04|[23]6|[48]9|50)|3(?:06|43|65)|4(?:03|1[68]|3[178]|50)|5(?:06|1[49]|48|79|8[17])|6(?:0[04]|13|22|39|47)|7(?:0[59]|78|8[02])|8(?:[06]7|19|25|73)|90[25])[2-9]\\d{6}|310\\d{4}" withPossibleNumberPattern:nil withPossibleLength:fixedLine_descArrayPL withPossibleLengthLocalOnly:nil withExample:@"2042345678" withNationalNumberMatcherData:nil withPossibleNumberMatcherData:nil];
+        self.fixedLine = [[NBPhoneNumberDesc alloc] initWithNationalNumberPattern:@"(?:2(?:04|[23]6|[48]9|50)|3(?:06|10|43|65)|4(?:03|1[68]|3[178]|50)|5(?:06|1[49]|48|79|8[17])|6(?:0[04]|13|22|39|47)|7(?:0[59]|78|8[02])|8(?:[06]7|19|25|73)|90[25])[2-9]\\d{6}" withPossibleNumberPattern:nil withPossibleLength:fixedLine_descArrayPL withPossibleLengthLocalOnly:nil withExample:@"2042345678" withNationalNumberMatcherData:nil withPossibleNumberMatcherData:nil];
 
         NSMutableArray *mobile_descArrayPL = [[NSMutableArray alloc] init];
         [mobile_descArrayPL addObject: [NSNumber numberWithInt:10]];
-        self.mobile = [[NBPhoneNumberDesc alloc] initWithNationalNumberPattern:@"(?:2(?:04|[23]6|[48]9|50)|3(?:06|43|65)|4(?:03|1[68]|3[178]|50)|5(?:06|1[49]|48|79|8[17])|6(?:0[04]|13|22|39|47)|7(?:0[59]|78|8[02])|8(?:[06]7|19|25|73)|90[25])[2-9]\\d{6}" withPossibleNumberPattern:nil withPossibleLength:mobile_descArrayPL withPossibleLengthLocalOnly:nil withExample:@"2042345678" withNationalNumberMatcherData:nil withPossibleNumberMatcherData:nil];
-        self.tollFree = [[NBPhoneNumberDesc alloc] initWithNationalNumberPattern:@"8(?:00|44|55|66|77|88)[2-9]\\d{6}|310\\d{4}" withPossibleNumberPattern:nil withPossibleLength:nil withPossibleLengthLocalOnly:nil withExample:@"8002123456" withNationalNumberMatcherData:nil withPossibleNumberMatcherData:nil];
+        self.mobile = [[NBPhoneNumberDesc alloc] initWithNationalNumberPattern:@"(?:2(?:04|[23]6|[48]9|50)|3(?:06|10|43|65)|4(?:03|1[68]|3[178]|50)|5(?:06|1[49]|48|79|8[17])|6(?:0[04]|13|22|39|47)|7(?:0[59]|78|8[02])|8(?:[06]7|19|25|73)|90[25])[2-9]\\d{6}" withPossibleNumberPattern:nil withPossibleLength:mobile_descArrayPL withPossibleLengthLocalOnly:nil withExample:@"2042345678" withNationalNumberMatcherData:nil withPossibleNumberMatcherData:nil];
+        self.tollFree = [[NBPhoneNumberDesc alloc] initWithNationalNumberPattern:@"8(?:00|44|55|66|77|88)[2-9]\\d{6}" withPossibleNumberPattern:nil withPossibleLength:nil withPossibleLengthLocalOnly:nil withExample:@"8002123456" withNationalNumberMatcherData:nil withPossibleNumberMatcherData:nil];
 
         NSMutableArray *premiumRate_descArrayPL = [[NSMutableArray alloc] init];
         [premiumRate_descArrayPL addObject: [NSNumber numberWithInt:10]];
@@ -22802,4 +22802,3 @@
     return self;
 }
 @end
-


### PR DESCRIPTION
The old regular expression was incorrectly matching "310XXXX" instead of "310[2-9]XXXXXX"