### PR TITLE
add solution to get country name in iOS8

### DIFF
--- a/libPhoneNumber/NBMetadataHelper.m
+++ b/libPhoneNumber/NBMetadataHelper.m
@@ -110,29 +110,32 @@ static NSMutableDictionary *kMapCCode2CN = nil;
 {
     NSArray *countryCodes = [NSLocale ISOCountryCodes];
     NSMutableArray *resultMetadata = [[NSMutableArray alloc] init];
-    
+
     for (NSString *countryCode in countryCodes) {
         id countryDictionaryInstance = [NSDictionary dictionaryWithObject:countryCode forKey:NSLocaleCountryCode];
         NSString *identifier = [NSLocale localeIdentifierFromComponents:countryDictionaryInstance];
         NSString *country = [[NSLocale currentLocale] displayNameForKey:NSLocaleIdentifier value:identifier];
-        
+        NSString *systemCountry = [[NSLocale systemLocale] displayNameForKey:NSLocaleIdentifier value:identifier];
+
         NSMutableDictionary *countryMeta = [[NSMutableDictionary alloc] init];
         if (country) {
             [countryMeta setObject:country forKey:@"name"];
+        } else if (systemCountry) {
+            [countryMeta setObject:systemCountry forKey:@"name"];
         }
-        
+
         if (countryCode) {
             [countryMeta setObject:countryCode forKey:@"code"];
         }
-        
+
         NBPhoneMetaData *metaData = [self getMetadataForRegion:countryCode];
         if (metaData) {
             [countryMeta setObject:metaData forKey:@"metadata"];
         }
-        
+
         [resultMetadata addObject:countryMeta];
     }
-    
+
     return resultMetadata;
 }
 
@@ -140,19 +143,19 @@ static NSMutableDictionary *kMapCCode2CN = nil;
 - (NSArray *)regionCodeFromCountryCode:(NSNumber *)countryCodeNumber
 {
     [self initializeHelper];
-    
+
     id res = nil;
-    
+
 #if TESTING==1
         res = [NBMetadataCoreTestMapper ISOCodeFromCallingNumber:[countryCodeNumber stringValue]];
 #else
         res = [NBMetadataCoreMapper ISOCodeFromCallingNumber:[countryCodeNumber stringValue]];
 #endif
-    
+
     if (res && [res isKindOfClass:[NSArray class]] && [((NSArray*)res) count] > 0) {
         return res;
     }
-    
+
     return nil;
 }
 
@@ -160,13 +163,13 @@ static NSMutableDictionary *kMapCCode2CN = nil;
 - (NSString *)countryCodeFromRegionCode:(NSString* )regionCode
 {
     [self initializeHelper];
-    
+
     id res = [kMapCCode2CN objectForKey:regionCode];
-    
+
     if (res) {
         return res;
     }
-    
+
     return nil;
 }
 
@@ -174,24 +177,24 @@ static NSMutableDictionary *kMapCCode2CN = nil;
 - (NSString *)stringByTrimming:(NSString *)aString
 {
     if (aString == nil || aString.length <= 0) return aString;
-    
+
     aString = [self normalizeNonBreakingSpace:aString];
-    
+
     NSString *aRes = @"";
     NSArray *newlines = [aString componentsSeparatedByCharactersInSet:[NSCharacterSet newlineCharacterSet]];
-    
+
     for (NSString *line in newlines) {
         NSString *performedString = [line stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
-        
+
         if (performedString.length > 0) {
             aRes = [aRes stringByAppendingString:performedString];
         }
     }
-    
+
     if (newlines.count <= 0) {
         return aString;
     }
-    
+
     return aRes;
 }
 
@@ -212,30 +215,30 @@ static NSMutableDictionary *kMapCCode2CN = nil;
 - (NBPhoneMetaData *)getMetadataForRegion:(NSString *)regionCode
 {
     [self initializeHelper];
-    
+
     if ([NBMetadataHelper hasValue:regionCode] == NO) {
         return nil;
     }
-    
+
     regionCode = [regionCode uppercaseString];
-    
+
     if (_cachedMetaDataKey && [_cachedMetaDataKey isEqualToString:regionCode]) {
         return _cachedMetaData;
     }
-    
+
     NSString *className = [NSString stringWithFormat:@"%@%@", NB_CLASS_PREFIX, regionCode];
-    
+
     Class metaClass = NSClassFromString(className);
-    
+
     if (metaClass) {
         NBPhoneMetaData *metadata = [[metaClass alloc] init];
-        
+
         _cachedMetaData = metadata;
         _cachedMetaDataKey = regionCode;
-        
+
         return metadata;
     }
-    
+
     return nil;
 }
 
@@ -262,11 +265,11 @@ static NSMutableDictionary *kMapCCode2CN = nil;
         [spaceCharSet formUnionWithCharacterSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
         whitespaceCharSet = spaceCharSet;
     });
-    
+
     if (string == nil || [string stringByTrimmingCharactersInSet:whitespaceCharSet].length <= 0) {
         return NO;
     }
-    
+
     return YES;
 }
 


### PR DESCRIPTION
`NSString *country = [[NSLocale currentLocale] displayNameForKey:NSLocaleIdentifier value:identifier];` 
The function above will catch empty country name in iOS 8.0.

Therefore, to support iOS 8 in country listing, I've added `[[NSLocale systemLocale] displayNameForKey:NSLocaleIdentifier value:identifier]` to retrieve default English country name if failed to get country name from `[NSLocale currentLocale]`.

Thank you for great library!