### PR TITLE
Fix xcode analysis warnings

### DIFF
--- a/libPhoneNumber/NBPhoneNumber.m
+++ b/libPhoneNumber/NBPhoneNumber.m
@@ -32,7 +32,7 @@
 
 - (NBECountryCodeSource)getCountryCodeSourceOrDefault
 {
-    if (!self.countryCodeSource) {
+    if (nil == self.countryCodeSource) {
         return NBECountryCodeSourceFROM_NUMBER_WITH_PLUS_SIGN;
     }
     

--- a/libPhoneNumber/NBPhoneNumberUtil.m
+++ b/libPhoneNumber/NBPhoneNumberUtil.m
@@ -1256,7 +1256,7 @@ static NSArray *GEO_MOBILE_COUNTRIES;
 {
     NBMetadataHelper *helper = self.helper;
     
-    return [NB_REGION_CODE_FOR_NON_GEO_ENTITY isEqualToString:regionCode] ?
+    return [regionCode isEqualToString:NB_REGION_CODE_FOR_NON_GEO_ENTITY] ?
         [helper getMetadataForNonGeographicalRegion:countryCallingCode] : [helper getMetadataForRegion:regionCode];
 }
 


### PR DESCRIPTION
* Using `NSNumber*` as boolean might be confusing. Making the test to `nil` explicit is clearer.
* Protect against `regionCode == nil` by reversing the order of the comparison.