### PR TITLE
Support for new Egyptian mobile number series

### DIFF
--- a/libPhoneNumber/NBMetadataCore.m
+++ b/libPhoneNumber/NBMetadataCore.m
@@ -19092,7 +19092,7 @@
 
         NSMutableArray *mobile_descArrayPL = [[NSMutableArray alloc] init];
         [mobile_descArrayPL addObject: [NSNumber numberWithInt:10]];
-        self.mobile = [[NBPhoneNumberDesc alloc] initWithNationalNumberPattern:@"1(?:0[0-269]|1[0-245]|2[0-278])\\d{7}" withPossibleNumberPattern:nil withPossibleLength:mobile_descArrayPL withPossibleLengthLocalOnly:nil withExample:@"1001234567" withNationalNumberMatcherData:nil withPossibleNumberMatcherData:nil];
+        self.mobile = [[NBPhoneNumberDesc alloc] initWithNationalNumberPattern:@"1(?:0[0-269]|1[0-245]|2[0-278]|5[0-9])\\d{7}" withPossibleNumberPattern:nil withPossibleLength:mobile_descArrayPL withPossibleLengthLocalOnly:nil withExample:@"1001234567" withNationalNumberMatcherData:nil withPossibleNumberMatcherData:nil];
 
         NSMutableArray *tollFree_descArrayPL = [[NSMutableArray alloc] init];
         [tollFree_descArrayPL addObject: [NSNumber numberWithInt:10]];


### PR DESCRIPTION
Added support for new Egyptian mobile number series. It starts with 015.

For example:

201501747129
201550937799