### PR TITLE
Improve Array additions performance

### DIFF
--- a/libPhoneNumber/NSArray+NBAdditions.m
+++ b/libPhoneNumber/NSArray+NBAdditions.m
@@ -11,14 +11,11 @@
 @implementation NSArray (NBAdditions)
 
 - (id)nb_safeObjectAtIndex:(NSUInteger)index class:(Class)clazz {
-    id res;
-    @synchronized(self) {
-        if (index >= [self count]) {
-            return nil;
-        }
-        res = [self objectAtIndex:index];
+    if (index >= self.count) {
+        return nil;
     }
-    if (res == nil || res == [NSNull null] || ![res isKindOfClass:clazz]) {
+    id res = [self objectAtIndex:index];
+    if (![res isKindOfClass:clazz]) {
         return nil;
     }
     return res;


### PR DESCRIPTION
There is no reason to have an @synchronized here. An NSArray by itself is
immutable so it is thread safe. An NSMutableArray by definition is not thread
safe if it is being accessed/mutated on multiple threads.

Other small enhancements to reduce number of calls being made.