### PR TITLE
Remove unused methods

### DIFF
--- a/libPhoneNumber/NBNumberFormat.m
+++ b/libPhoneNumber/NBNumberFormat.m
@@ -56,6 +56,11 @@
 }
 
 
+#ifdef NB_USE_EXTENSIONS
+// We believe these methods are unused.
+// If you would like them back (not behind a flag) please file a bug with a reason for needing
+// them.
+
 - (instancetype)initWithCoder:(NSCoder*)coder
 {
     if (self = [super init]) {
@@ -80,5 +85,6 @@
     [coder encodeObject:self.domesticCarrierCodeFormattingRule forKey:@"domesticCarrierCodeFormattingRule"];
 }
 
+#endif // NB_USE_EXTENSIONS
 
 @end

--- a/libPhoneNumber/NBPhoneMetaData.m
+++ b/libPhoneNumber/NBPhoneMetaData.m
@@ -80,6 +80,10 @@
              _codeID, _countryCode, _generalDesc, _fixedLine, _mobile, _tollFree, _premiumRate, _sharedCost, _personalNumber, _voip, _pager, _uan, _emergency, _voicemail, _noInternationalDialling, _internationalPrefix, _preferredInternationalPrefix, _nationalPrefix, _preferredExtnPrefix, _nationalPrefixForParsing, _nationalPrefixTransformRule, _sameMobileAndFixedLinePattern?@"Y":@"N", _numberFormats, _intlNumberFormats, _mainCountryForCode?@"Y":@"N", _leadingDigits, _leadingZeroPossible?@"Y":@"N"];
 }
 
+#ifdef NB_USE_EXTENSIONS
+// We believe these methods are unused.
+// If you would like them back (not behind a flag) please file a bug with a reason for needing
+// them.
 
 - (instancetype)initWithCoder:(NSCoder*)coder
 {
@@ -147,5 +151,6 @@
     [coder encodeObject:[NSNumber numberWithBool:_leadingZeroPossible] forKey:@"leadingZeroPossible"];
 }
 
+#endif // NB_USE_EXTENSIONS
 
 @end

--- a/libPhoneNumber/NBPhoneNumberDesc.m
+++ b/libPhoneNumber/NBPhoneNumberDesc.m
@@ -25,6 +25,19 @@
 }
 
 
+
+
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"nationalNumberPattern[%@] possibleNumberPattern[%@] possibleLength[%@] possibleLengthLocalOnly[%@] exampleNumber[%@]",
+            self.nationalNumberPattern, self.possibleNumberPattern, self.possibleLength, self.possibleLengthLocalOnly, self.exampleNumber];
+}
+
+#ifdef NB_USE_EXTENSIONS
+// We believe these methods are unused.
+// If you would like them back (not behind a flag) please file a bug with a reason for needing
+// them.
+
 - (instancetype)initWithCoder:(NSCoder*)coder
 {
     if (self = [super init]) {
@@ -52,13 +65,6 @@
 }
 
 
-- (NSString *)description
-{
-    return [NSString stringWithFormat:@"nationalNumberPattern[%@] possibleNumberPattern[%@] possibleLength[%@] possibleLengthLocalOnly[%@] exampleNumber[%@]",
-            self.nationalNumberPattern, self.possibleNumberPattern, self.possibleLength, self.possibleLengthLocalOnly, self.exampleNumber];
-}
-
-
 - (id)copyWithZone:(NSZone *)zone
 {
   return self;
@@ -80,5 +86,7 @@
         [self.nationalNumberMatcherData isEqualToData:other.nationalNumberMatcherData] &&
         [self.possibleNumberMatcherData isEqualToData:other.possibleNumberMatcherData];
 }
+
+#endif // NB_USE_EXTENSIONS
 
 @end


### PR DESCRIPTION
I believe that the coding and copy methods in these classes are unused.
I have disabled them behind an #ifdef flag.
If no one files any bugs, we can remove them.