### PR TITLE
Improve phone number parsing performance by 28-32%

### DIFF
--- a/libPhoneNumber.xcodeproj/project.pbxproj
+++ b/libPhoneNumber.xcodeproj/project.pbxproj
@@ -35,10 +35,9 @@
 		0F2870B11FCF9620006230BF /* NBRegularExpressionCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 0F2870A11FCF9368006230BF /* NBRegularExpressionCache.m */; };
 		0F2870B21FCF9620006230BF /* NBRegularExpressionCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 0F2870A11FCF9368006230BF /* NBRegularExpressionCache.m */; };
 		0F4D824C1FCF60A5009F9C17 /* NBShortNumberInfoTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 0F4D824B1FCF60A5009F9C17 /* NBShortNumberInfoTest.m */; };
-		0F58330B1FD1FC9500F26ED4 /* NBPhoneNumberUtil+ShortNumberTest.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F5833091FD1FC9500F26ED4 /* NBPhoneNumberUtil+ShortNumberTest.h */; };
-		0F58330D1FD1FD1400F26ED4 /* NBPhoneNumberUtil+ShortNumberTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 0F58330A1FD1FC9500F26ED4 /* NBPhoneNumberUtil+ShortNumberTest.m */; };
 		0F58330B1FD1FC9500F26ED4 /* NBPhoneNumberUtil+ShortNumberTestHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F5833091FD1FC9500F26ED4 /* NBPhoneNumberUtil+ShortNumberTestHelper.h */; };
 		0F58330D1FD1FD1400F26ED4 /* NBPhoneNumberUtil+ShortNumberTestHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 0F58330A1FD1FC9500F26ED4 /* NBPhoneNumberUtil+ShortNumberTestHelper.m */; };
+		0FAE11912037959800193503 /* NBPhoneNumberParsingPerfTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FAE11902037959800193503 /* NBPhoneNumberParsingPerfTest.m */; };
 		1485C5271E06F4890092F541 /* NBAsYouTypeFormatterTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1485C5231E06F4890092F541 /* NBAsYouTypeFormatterTest.m */; };
 		1485C5291E06F4890092F541 /* NBPhoneNumberUtilTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1485C5251E06F4890092F541 /* NBPhoneNumberUtilTest.m */; };
 		14B7A2AB1DE9BF160051AED7 /* NBMetadataHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = FD12C2691A87401B00B53856 /* NBMetadataHelper.m */; };
@@ -181,10 +180,9 @@
 		0F2870A11FCF9368006230BF /* NBRegularExpressionCache.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NBRegularExpressionCache.m; sourceTree = "<group>"; };
 		0F4D82491FCF5CFB009F9C17 /* ShortNumberMetadata.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; name = ShortNumberMetadata.json; path = libPhoneNumberTests/generatedJSON/ShortNumberMetadata.json; sourceTree = "<group>"; };
 		0F4D824B1FCF60A5009F9C17 /* NBShortNumberInfoTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NBShortNumberInfoTest.m; sourceTree = "<group>"; };
-		0F5833091FD1FC9500F26ED4 /* NBPhoneNumberUtil+ShortNumberTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NBPhoneNumberUtil+ShortNumberTest.h"; sourceTree = "<group>"; };
-		0F58330A1FD1FC9500F26ED4 /* NBPhoneNumberUtil+ShortNumberTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NBPhoneNumberUtil+ShortNumberTest.m"; sourceTree = "<group>"; };
 		0F5833091FD1FC9500F26ED4 /* NBPhoneNumberUtil+ShortNumberTestHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NBPhoneNumberUtil+ShortNumberTestHelper.h"; sourceTree = "<group>"; };
 		0F58330A1FD1FC9500F26ED4 /* NBPhoneNumberUtil+ShortNumberTestHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NBPhoneNumberUtil+ShortNumberTestHelper.m"; sourceTree = "<group>"; };
+		0FAE11902037959800193503 /* NBPhoneNumberParsingPerfTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NBPhoneNumberParsingPerfTest.m; sourceTree = "<group>"; };
 		1485C5231E06F4890092F541 /* NBAsYouTypeFormatterTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = NBAsYouTypeFormatterTest.m; path = libPhoneNumberTests/NBAsYouTypeFormatterTest.m; sourceTree = SOURCE_ROOT; };
 		1485C5251E06F4890092F541 /* NBPhoneNumberUtilTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = NBPhoneNumberUtilTest.m; path = libPhoneNumberTests/NBPhoneNumberUtilTest.m; sourceTree = SOURCE_ROOT; };
 		1485C52B1E06F4930092F541 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = libPhoneNumberTests/Info.plist; sourceTree = SOURCE_ROOT; };
@@ -321,7 +319,6 @@
 				0F2870971FCF8F13006230BF /* NBRegExMatcher.m */,
 				0F2870A01FCF9368006230BF /* NBRegularExpressionCache.h */,
 				0F2870A11FCF9368006230BF /* NBRegularExpressionCache.m */,
-				0F58330E1FD2004A00F26ED4 /* NBPhoneNumberUtil+Category.h */,
 			);
 			path = Internal;
 			sourceTree = "<group>";
@@ -349,12 +346,11 @@
 		14B7A2941DE9B65D0051AED7 /* libPhoneNumber.tests */ = {
 			isa = PBXGroup;
 			children = (
+				0FAE11902037959800193503 /* NBPhoneNumberParsingPerfTest.m */,
 				1485C52B1E06F4930092F541 /* Info.plist */,
 				1485C5231E06F4890092F541 /* NBAsYouTypeFormatterTest.m */,
 				1485C5251E06F4890092F541 /* NBPhoneNumberUtilTest.m */,
 				0F4D824B1FCF60A5009F9C17 /* NBShortNumberInfoTest.m */,
-				0F5833091FD1FC9500F26ED4 /* NBPhoneNumberUtil+ShortNumberTest.h */,
-				0F58330A1FD1FC9500F26ED4 /* NBPhoneNumberUtil+ShortNumberTest.m */,
 				0F5833091FD1FC9500F26ED4 /* NBPhoneNumberUtil+ShortNumberTestHelper.h */,
 				0F58330A1FD1FC9500F26ED4 /* NBPhoneNumberUtil+ShortNumberTestHelper.m */,
 			);
@@ -597,7 +593,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8B1FEFA01EB7BFC500FBDE87 /* NBGeneratedPhoneNumberMetaData.h in Headers */,
-				0F58330B1FD1FC9500F26ED4 /* NBPhoneNumberUtil+ShortNumberTest.h in Headers */,
+				0F58330B1FD1FC9500F26ED4 /* NBPhoneNumberUtil+ShortNumberTestHelper.h in Headers */,
 				0F58330B1FD1FC9500F26ED4 /* NBPhoneNumberUtil+ShortNumberTestHelper.h in Headers */,
 				0F2870981FCF8F13006230BF /* NBRegExMatcher.h in Headers */,
 				34ACBBB61B7124AB0064B3BD /* NBPhoneNumberDefines.h in Headers */,
@@ -900,7 +896,7 @@
 				14B7A2B31DE9BF160051AED7 /* NBPhoneMetaData.m in Sources */,
 				14B7A2B41DE9BF160051AED7 /* NBPhoneNumberDefines.m in Sources */,
 				1485C5271E06F4890092F541 /* NBAsYouTypeFormatterTest.m in Sources */,
-				0F58330D1FD1FD1400F26ED4 /* NBPhoneNumberUtil+ShortNumberTest.m in Sources */,
+				0F58330D1FD1FD1400F26ED4 /* NBPhoneNumberUtil+ShortNumberTestHelper.m in Sources */,
 				0F58330D1FD1FD1400F26ED4 /* NBPhoneNumberUtil+ShortNumberTestHelper.m in Sources */,
 				14B7A2B51DE9BF160051AED7 /* NBPhoneNumberUtil.m in Sources */,
 				0F2870AF1FCF961C006230BF /* NBRegExMatcher.m in Sources */,
@@ -980,6 +976,7 @@
 				34ACBBAA1B7122F80064B3BD /* NBPhoneNumber.m in Sources */,
 				0F28709C1FCF8F13006230BF /* NBRegExMatcher.m in Sources */,
 				34ACBBAE1B7123090064B3BD /* NBPhoneNumberUtil.m in Sources */,
+				0FAE11912037959800193503 /* NBPhoneNumberParsingPerfTest.m in Sources */,
 				34ACBBAB1B7122FD0064B3BD /* NBNumberFormat.m in Sources */,
 				34ACBBAD1B7123020064B3BD /* NBPhoneMetaData.m in Sources */,
 				34ACBBB01B71230E0064B3BD /* NBAsYouTypeFormatter.m in Sources */,

--- a/libPhoneNumber.xcodeproj/project.pbxproj
+++ b/libPhoneNumber.xcodeproj/project.pbxproj
@@ -34,10 +34,10 @@
 		0F2870B01FCF961D006230BF /* NBRegExMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 0F2870971FCF8F13006230BF /* NBRegExMatcher.m */; };
 		0F2870B11FCF9620006230BF /* NBRegularExpressionCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 0F2870A11FCF9368006230BF /* NBRegularExpressionCache.m */; };
 		0F2870B21FCF9620006230BF /* NBRegularExpressionCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 0F2870A11FCF9368006230BF /* NBRegularExpressionCache.m */; };
+		0F4314DC203CA833005FE065 /* NBPhoneNumberParsingPerfTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FAE11902037959800193503 /* NBPhoneNumberParsingPerfTest.m */; };
 		0F4D824C1FCF60A5009F9C17 /* NBShortNumberInfoTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 0F4D824B1FCF60A5009F9C17 /* NBShortNumberInfoTest.m */; };
 		0F58330B1FD1FC9500F26ED4 /* NBPhoneNumberUtil+ShortNumberTestHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F5833091FD1FC9500F26ED4 /* NBPhoneNumberUtil+ShortNumberTestHelper.h */; };
 		0F58330D1FD1FD1400F26ED4 /* NBPhoneNumberUtil+ShortNumberTestHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 0F58330A1FD1FC9500F26ED4 /* NBPhoneNumberUtil+ShortNumberTestHelper.m */; };
-		0FAE11912037959800193503 /* NBPhoneNumberParsingPerfTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FAE11902037959800193503 /* NBPhoneNumberParsingPerfTest.m */; };
 		1485C5271E06F4890092F541 /* NBAsYouTypeFormatterTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1485C5231E06F4890092F541 /* NBAsYouTypeFormatterTest.m */; };
 		1485C5291E06F4890092F541 /* NBPhoneNumberUtilTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1485C5251E06F4890092F541 /* NBPhoneNumberUtilTest.m */; };
 		14B7A2AB1DE9BF160051AED7 /* NBMetadataHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = FD12C2691A87401B00B53856 /* NBMetadataHelper.m */; };
@@ -886,7 +886,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1485C5291E06F4890092F541 /* NBPhoneNumberUtilTest.m in Sources */,
-				0FAE11922037990100193503 /* NBPhoneNumberParsingPerfTest.m in Sources */,
+				0F4314DC203CA833005FE065 /* NBPhoneNumberParsingPerfTest.m in Sources */,
 				14B7A2AB1DE9BF160051AED7 /* NBMetadataHelper.m in Sources */,
 				14B7A2B01DE9BF160051AED7 /* NBPhoneNumber.m in Sources */,
 				0F4D824C1FCF60A5009F9C17 /* NBShortNumberInfoTest.m in Sources */,
@@ -977,7 +977,6 @@
 				34ACBBAA1B7122F80064B3BD /* NBPhoneNumber.m in Sources */,
 				0F28709C1FCF8F13006230BF /* NBRegExMatcher.m in Sources */,
 				34ACBBAE1B7123090064B3BD /* NBPhoneNumberUtil.m in Sources */,
-				0FAE11912037959800193503 /* NBPhoneNumberParsingPerfTest.m in Sources */,
 				34ACBBAB1B7122FD0064B3BD /* NBNumberFormat.m in Sources */,
 				34ACBBAD1B7123020064B3BD /* NBPhoneMetaData.m in Sources */,
 				34ACBBB01B71230E0064B3BD /* NBAsYouTypeFormatter.m in Sources */,

--- a/libPhoneNumber.xcodeproj/project.pbxproj
+++ b/libPhoneNumber.xcodeproj/project.pbxproj
@@ -886,6 +886,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1485C5291E06F4890092F541 /* NBPhoneNumberUtilTest.m in Sources */,
+				0FAE11922037990100193503 /* NBPhoneNumberParsingPerfTest.m in Sources */,
 				14B7A2AB1DE9BF160051AED7 /* NBMetadataHelper.m in Sources */,
 				14B7A2B01DE9BF160051AED7 /* NBPhoneNumber.m in Sources */,
 				0F4D824C1FCF60A5009F9C17 /* NBShortNumberInfoTest.m in Sources */,

--- a/libPhoneNumber/NBMetadataHelper.m
+++ b/libPhoneNumber/NBMetadataHelper.m
@@ -13,8 +13,7 @@
 @interface NBMetadataHelper ()
 
 // Cached metadata
-@property(nonatomic, strong) NBPhoneMetaData *cachedMetaData;
-@property(nonatomic, strong) NSString *cachedMetaDataKey;
+@property (nonatomic, strong) NSCache<NSString *, NBPhoneMetaData *> *metadataCache;
 
 #if SHORT_NUMBER_SUPPORT
 
@@ -38,6 +37,14 @@ static NSString *StringByTrimming(NSString *aString) {
 }
 
 @implementation NBMetadataHelper
+
+- (instancetype)init {
+  self = [super init];
+  if (self != nil) {
+    _metadataCache = [[NSCache alloc] init];
+  }
+  return self;
+}
 
 /*
  Terminologies
@@ -142,16 +149,17 @@ static NSString *StringByTrimming(NSString *aString) {
 
   regionCode = [regionCode uppercaseString];
 
-  if ([_cachedMetaDataKey isEqualToString:regionCode]) {
-    return _cachedMetaData;
+  NBPhoneMetaData *cachedMetadata = [_metadataCache objectForKey:regionCode];
+  if (cachedMetadata != nil) {
+    return cachedMetadata;
   }
 
   NSDictionary *dict = [[self class] phoneNumberDataMap][@"countryToMetadata"];
   NSArray *entry = dict[regionCode];
   if (entry) {
     NBPhoneMetaData *metadata = [[NBPhoneMetaData alloc] initWithEntry:entry];
-    _cachedMetaData = metadata;
-    _cachedMetaDataKey = regionCode;
+    [_metadataCache setObject:metadata forKey:regionCode];
+
     return metadata;
   }
 

--- a/libPhoneNumber/NBMetadataHelper.m
+++ b/libPhoneNumber/NBMetadataHelper.m
@@ -203,21 +203,16 @@ static NSString *StringByTrimming(NSString *aString) {
 
     regionCode = [regionCode uppercaseString];
 
-  @synchronized(_shortNumberMetadataCache) {
-    NBPhoneMetaData *cachedMetadata = [_shortNumberMetadataCache objectForKey:regionCode];
-    if (cachedMetadata != nil) {
-      return cachedMetadata;
-    }
+  NBPhoneMetaData *cachedMetadata = [_shortNumberMetadataCache objectForKey:regionCode];
+  if (cachedMetadata != nil) {
+    return cachedMetadata;
   }
 
   NSDictionary *dict = [[self class] shortNumberDataMap][@"countryToMetadata"];
   NSArray *entry = dict[regionCode];
   if (entry) {
     NBPhoneMetaData *metadata = [[NBPhoneMetaData alloc] initWithEntry:entry];
-    @synchronized(_shortNumberMetadataCache) {
-      [_shortNumberMetadataCache setObject:metadata forKey:regionCode];
-    }
-
+    [_shortNumberMetadataCache setObject:metadata forKey:regionCode];
     return metadata;
   }
 

--- a/libPhoneNumber/NBMetadataHelper.m
+++ b/libPhoneNumber/NBMetadataHelper.m
@@ -41,7 +41,9 @@ static NSString *StringByTrimming(NSString *aString) {
   self = [super init];
   if (self != nil) {
     _metadataCache = [[NSCache alloc] init];
+#if SHORT_NUMBER_SUPPORT
     _shortNumberMetadataCache = [[NSCache alloc] init];
+#endif //SHORT_NUMBER_SUPPORT
   }
   return self;
 }

--- a/libPhoneNumber/NBPhoneNumberUtil.m
+++ b/libPhoneNumber/NBPhoneNumberUtil.m
@@ -33,7 +33,7 @@ static BOOL isNan(NSString *sourceString) {
   });
 
   // Return YES if the sourceString doesn't have any characters that can be represented as a Float.
-  return !([sourceString rangeOfCharacterFromSet:nonDecimalCharacterSet].length == NSNotFound);
+  return !([sourceString rangeOfCharacterFromSet:nonDecimalCharacterSet].location == NSNotFound);
 }
 
 #pragma mark - NBPhoneNumberUtil interface -

--- a/libPhoneNumberTests/NBPhoneNumberParsingPerfTest.m
+++ b/libPhoneNumberTests/NBPhoneNumberParsingPerfTest.m
@@ -83,8 +83,6 @@
     [exampleNumbers addObjectsFromArray:exampleNumbers];
   }
 
-  NSLog(@"Count: %@", @(exampleNumbers.count));
-
   [self measureBlock:^{
     for (NBExampleNumber *example in exampleNumbers) {
       [util parseAndKeepRawInput:example.phoneNumber

--- a/libPhoneNumberTests/NBPhoneNumberParsingPerfTest.m
+++ b/libPhoneNumberTests/NBPhoneNumberParsingPerfTest.m
@@ -44,8 +44,8 @@
 @end
 
 @implementation NBPhoneNumberParsingPerfTest
-//#define PERF_TEST
-//#if PERF_TEST
+
+#if PERF_TEST
 
 - (void)testParsing {
   NSArray *regionCodes = [[NBMetadataHelper CCode2CNMap] allKeys];
@@ -94,6 +94,6 @@
   }];
 }
 
-//#endif // PERF_TEST
+#endif // PERF_TEST
 
 @end

--- a/libPhoneNumberTests/NBPhoneNumberParsingPerfTest.m
+++ b/libPhoneNumberTests/NBPhoneNumberParsingPerfTest.m
@@ -1,0 +1,99 @@
+//
+//  NBPhoneNumberParsingPerfTest.m
+//  libPhoneNumberiOSTests
+//
+//  Created by Paween Itthipalkul on 2/1/18.
+//  Copyright © 2018 Google LLC. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <XCTest/XCTest.h>
+#import "NBMetadataHelper.h"
+#import "NBPhoneMetaData.h"
+
+#import "NBNumberFormat.h"
+#import "NBPhoneNumber.h"
+#import "NBPhoneNumberDesc.h"
+#import "NBPhoneNumberUtil.h"
+
+@interface NBExampleNumber: NSObject
+
+@property (nonatomic, strong) NSString *phoneNumber;
+@property (nonatomic, strong) NSString *baseRegionCode;
+
+- (instancetype)initWithPhoneNumber:(NSString *)phoneNumber
+                     baseRegionCode:(NSString *)baseRegionCode;
+
+@end
+
+@implementation NBExampleNumber
+- (instancetype)initWithPhoneNumber:(NSString *)phoneNumber
+                     baseRegionCode:(NSString *)baseRegionCode {
+  self = [super init];
+  if (self != nil) {
+    _phoneNumber = phoneNumber;
+    _baseRegionCode = baseRegionCode;
+  }
+
+  return self;
+}
+@end
+
+
+@interface NBPhoneNumberParsingPerfTest: XCTestCase
+@end
+
+@implementation NBPhoneNumberParsingPerfTest
+//#define PERF_TEST
+//#if PERF_TEST
+
+- (void)testParsing {
+  NSArray *regionCodes = [[NBMetadataHelper CCode2CNMap] allKeys];
+
+  NSMutableArray<NBExampleNumber *> *exampleNumbers = [[NSMutableArray alloc] init];
+
+  NBPhoneNumberUtil *util = [NBPhoneNumberUtil sharedInstance];
+
+  for (NSString *regionCode in regionCodes) {
+    NBPhoneNumber *phoneNumber = [util getExampleNumber:regionCode error:nil];
+    if (phoneNumber != nil) {
+      NSString *e164 = [util format:phoneNumber numberFormat:NBEPhoneNumberFormatE164 error:nil];
+      NBExampleNumber *e164Sample = [[NBExampleNumber alloc] initWithPhoneNumber:e164
+                                                                  baseRegionCode:regionCode];
+      [exampleNumbers addObject:e164Sample];
+
+      NSString *national = [util format:phoneNumber
+                           numberFormat:NBEPhoneNumberFormatNATIONAL
+                                  error:nil];
+      NBExampleNumber *nationalSample = [[NBExampleNumber alloc] initWithPhoneNumber:national
+                                                                      baseRegionCode:regionCode];
+      [exampleNumbers addObject:nationalSample];
+
+      // intl format sample.
+      NSString *intl = [util format:phoneNumber
+                       numberFormat:NBEPhoneNumberFormatINTERNATIONAL
+                              error:nil];
+      NBExampleNumber * intlSample = [[NBExampleNumber alloc] initWithPhoneNumber:intl
+                                                                   baseRegionCode:regionCode];
+      [exampleNumbers addObject:intlSample];
+    }
+  }
+
+  for (int i = 0; i < 5; i++) {
+    [exampleNumbers addObjectsFromArray:exampleNumbers];
+  }
+
+  NSLog(@"Count: %@", @(exampleNumbers.count));
+
+  [self measureBlock:^{
+    for (NBExampleNumber *example in exampleNumbers) {
+      [util parseAndKeepRawInput:example.phoneNumber
+                   defaultRegion:example.baseRegionCode
+                           error:nil];
+    }
+  }];
+}
+
+//#endif // PERF_TEST
+
+@end


### PR DESCRIPTION
Improve phone number parsing performance ~28-32%

Improve phone number parsing performance by:
- Using NSCache to cache metadata, so when parsing phone numbers from different regions, the metadata cache is still going to be valid.
- Improve various methods in NBPhoneNumberUtil by removing redundant operations, or using a different construct that’s more performant (such as using NSCharacterSet instead of NSScanner to check if a string is a number).

Also added a performance test that reads sample phone numbers from the metadata, and parse them. Performance test can be enabled by defining PERF_TEST when compiling.

Performance improvement result:
Machine:
Mac Pro (Late 2013)
2.7 GHz. 12-Core Intel Xeon E5
64 GB 1866 MHz DDR3
macOS High Sierra 10.13.3

Phone number to parse count: 2688

Baseline (5 runs -- in seconds):
0.362
0.372
0.385
0.363
0.365

After Change (5 runs -- in seconds):
0.250 (31% faster)
0.260 (28% faster)
0.256 (29% faster)
0.247 (32% faster)
0.251 (31% faster)