### PR TITLE
Remove unused NBRegExMatcher reference

### DIFF
--- a/libPhoneNumber/NBPhoneNumberUtil+ShortNumber.m
+++ b/libPhoneNumber/NBPhoneNumberUtil+ShortNumber.m
@@ -14,7 +14,6 @@
 #import "NBPhoneMetaData.h"
 #import "NBPhoneNumber.h"
 #import "NBPhoneNumberDesc.h"
-#import "NBRegExMatcher.h"
 #import "NBRegularExpressionCache.h"
 
 #if SHORT_NUMBER_SUPPORT
@@ -24,7 +23,6 @@ static NSString * const PLUS_CHARS_PATTERN = @"[+\uFF0B]+";
 @interface NBPhoneNumberUtil()
 
 @property(nonatomic, strong, readonly) NBMetadataHelper *helper;
-@property(nonatomic, strong, readonly) NBRegExMatcher *matcher;
 
 @property (nonatomic) NSDictionary<NSNumber *, NSArray<NSString *> *> *countryToRegionCodeMap;
 

--- a/libPhoneNumber/NBPhoneNumberUtil.m
+++ b/libPhoneNumber/NBPhoneNumberUtil.m
@@ -14,7 +14,6 @@
 #import "NBPhoneNumber.h"
 #import "NBPhoneNumberDefines.h"
 #import "NBPhoneNumberDesc.h"
-#import "NBRegExMatcher.h"
 
 #if TARGET_OS_IOS
 #import <CoreTelephony/CTCarrier.h>
@@ -50,7 +49,6 @@ static BOOL isNan(NSString *sourceString) {
 @property(nonatomic, strong) NSRegularExpression *VALID_ALPHA_PHONE_PATTERN;
 
 @property(nonatomic, strong, readwrite) NBMetadataHelper *helper;
-@property(nonatomic, strong, readwrite) NBRegExMatcher *matcher;
 
 #if TARGET_OS_IOS
 @property(nonatomic, readonly) CTTelephonyNetworkInfo *telephonyNetworkInfo;
@@ -402,7 +400,6 @@ static NSArray *GEO_MOBILE_COUNTRIES;
     _lockPatternCache = [[NSLock alloc] init];
     _entireStringCacheLock = [[NSLock alloc] init];
     _helper = [[NBMetadataHelper alloc] init];
-    _matcher = [[NBRegExMatcher alloc] init];
     [self initRegularExpressionSet];
     [self initNormalizationMappings];
   }


### PR DESCRIPTION
This looks like it's being unused. Also, the podspec doesn't even include the NBRegExMatcher.{h/m} files so compilation fails when using this pod.