### PR TITLE
Update pod spec file

### DIFF
--- a/libPhoneNumber-iOS.podspec
+++ b/libPhoneNumber-iOS.podspec
@@ -19,5 +19,5 @@ DESC
   s.tvos.deployment_target = "9.0"
   s.requires_arc = true
   s.private_header_files = 'libPhoneNumber/NBGeneratedPhoneNumberMetaData.h'
-  s.source_files = 'libPhoneNumber/NBPhoneNumberDefines.{h,m}', 'libPhoneNumber/NBPhoneNumber.{h,m}', 'libPhoneNumber/NBNumberFormat.{h,m}', 'libPhoneNumber/NBPhoneNumberDesc.{h,m}', 'libPhoneNumber/NBPhoneMetaData.{h,m}', 'libPhoneNumber/NBPhoneNumberUtil.{h,m}', 'libPhoneNumber/NBMetadataHelper.{h,m}', 'libPhoneNumber/NBAsYouTypeFormatter.{h,m}', 'libPhoneNumber/NSArray+NBAdditions.{h,m}', 'libPhoneNumber/NBGeneratedPhoneNumberMetaData.h', 'libPhoneNumber/NBRegExMatcher.{h,m}'
+  s.source_files = 'libPhoneNumber/NBPhoneNumberDefines.{h,m}', 'libPhoneNumber/NBPhoneNumber.{h,m}', 'libPhoneNumber/NBNumberFormat.{h,m}', 'libPhoneNumber/NBPhoneNumberDesc.{h,m}', 'libPhoneNumber/NBPhoneMetaData.{h,m}', 'libPhoneNumber/NBPhoneNumberUtil.{h,m}', 'libPhoneNumber/NBMetadataHelper.{h,m}', 'libPhoneNumber/NBAsYouTypeFormatter.{h,m}', 'libPhoneNumber/NSArray+NBAdditions.{h,m}', 'libPhoneNumber/NBGeneratedPhoneNumberMetaData.h', 'libPhoneNumber/Internal/NBRegExMatcher.{h,m}', 'libPhoneNumber/Internal/NBRegularExpressionCache.{h,m}'
 end

--- a/libPhoneNumber-iOS.podspec
+++ b/libPhoneNumber-iOS.podspec
@@ -11,6 +11,7 @@ DESC
   s.authors      = { "iziz" => "zen.isis@gmail.com", "hyukhur" => "hyukhur@gmail.com" }
   s.source       = { :git => "https://github.com/iziz/libPhoneNumber-iOS.git", :tag => s.version.to_s }
   s.libraries 	 = 'z'
+  s.module_name  = "libPhoneNumberiOS"
   s.ios.framework    = 'CoreTelephony'
   s.ios.deployment_target = "6.0"
   s.osx.deployment_target = "10.9"


### PR DESCRIPTION
My initial change here was to set the module_name so that it matches what Carthage would use (and appears to be what is expected anyway). This would obviously be a breaking change for anyone who's currently using this via CocoaPods, although like I say this appears to be the correct module name anyway.

I also found that the latest version wouldn't actually run with CocoaPods though so tweaked the source_files attribute so that it now compiles.