### PR TITLE
Fix for issue flagged by static analyzer

### DIFF
--- a/libPhoneNumber/NBAsYouTypeFormatter.m
+++ b/libPhoneNumber/NBAsYouTypeFormatter.m
@@ -770,8 +770,6 @@ static const NSUInteger NBMinLeadingDigitsLength = 3;
         return [self attemptToChooseFormattingPattern_];
       }
   }
-
-  _isSuccessfulFormatting = NO;
 }
 
 /**


### PR DESCRIPTION
The removed line is not reachable.

I run the Coverity static analyzer in our code which uses the libPhoneNumber and flagged the line as not reachable. I think it is right. All paths in the switch statement before this line end up in a "return" keyword.

A separate reported issue not covered by this Pull Request:
Actually, there was a second issue reported, I think it might be intentional, but I did not feel knowledgeable enough to modify the code. In the switch case 3, one code path ends up in a return, the other path sets self.isExpectingCountryCallingCode_  to YES, but there is not break or comment about why it is not used. I think the break was not added so it falls-trough and the code in the "default" case could be executed. Anyways, a comment around case 3 on why a break is not used would help other people reading the code.