### PR TITLE
Fix 'umbrella header for module does not include...' error

### DIFF
--- a/libPhoneNumber-iOS/libPhoneNumberiOS.h
+++ b/libPhoneNumber-iOS/libPhoneNumberiOS.h
@@ -25,6 +25,7 @@ FOUNDATION_EXPORT const unsigned char libPhoneNumber_iOSVersionString[];
 
 // Metadata
 #import "NBMetadataHelper.h"
+#import "NBGeocoderMetadataHelper.h"
 
 // Model
 #import "NBNumberFormat.h"


### PR DESCRIPTION
Closes #313 

See the issue for reproduction details. This just adds the new header to the "umbrella header" (libPhoneNumberiOS.h).