### PR TITLE
Fixed supported platforms when building with carthage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,10 +176,10 @@ override func viewDidLoad() {
 
 ## libPhoneNumberGeocoding
 
-For more information on libPhoneNumberGeocoding and its usage, please visit [libPhoneNumberGeocoding](https://github.com/iziz/libPhoneNumber-iOS/libPhoneNumberGeocoding/README.md) for more information.
+For more information on libPhoneNumberGeocoding and its usage, please visit [libPhoneNumberGeocoding](https://github.com/iziz/libPhoneNumber-iOS/blob/master/libPhoneNumberGeocoding/README.md) for more information.
 
 ## libPhoneNumberShortNumber
 
-For more information on libPhoneNumberShortNumber and its usage, please visit [libPhoneNumberShortNumber](https://github.com/iziz/libPhoneNumber-iOS/libPhoneNumberShortNumber/README.md) for more information.
+For more information on libPhoneNumberShortNumber and its usage, please visit [libPhoneNumberShortNumber](https://github.com/iziz/libPhoneNumber-iOS/blob/master/libPhoneNumberShortNumber/README.md) for more information.
 
 ##### Visit [libphonenumber](https://github.com/google/libphonenumber) for more information or mail (zen.isis@gmail.com)

--- a/libPhoneNumber.xcodeproj/project.pbxproj
+++ b/libPhoneNumber.xcodeproj/project.pbxproj
@@ -1108,7 +1108,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = me.ohtalk.libPhoneNumber.iOS;
 				PRODUCT_NAME = libPhoneNumberiOS;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos watchsimulator watchos appletvos appletvsimulator macosx";
 				SUPPORTS_MACCATALYST = NO;
 				TVOS_DEPLOYMENT_TARGET = 10.0;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -1159,7 +1158,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = me.ohtalk.libPhoneNumber.iOS;
 				PRODUCT_NAME = libPhoneNumberiOS;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos watchsimulator watchos appletvos appletvsimulator macosx";
 				SUPPORTS_MACCATALYST = NO;
 				TVOS_DEPLOYMENT_TARGET = 10.0;
 				VERSIONING_SYSTEM = "apple-generic";


### PR DESCRIPTION
When trying to build with carthage, I was getting the error "CoreTelephony is not available when building for platform xxx" with these platforms set.
Also fixed those readme links.

Please let me know if you would like to handle this issue differently.
