### PR TITLE
Add Package@swift-5.0.swift

### DIFF
--- a/Package@swift-5.0.swift
+++ b/Package@swift-5.0.swift
@@ -1,0 +1,42 @@
+// swift-tools-version:5.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+import PackageDescription
+
+let package = Package(
+    name: "libPhoneNumber",
+    platforms: [
+        .macOS(.v10_10),
+        .iOS(.v8),
+        .tvOS(.v9),
+        .watchOS(.v2)
+    ],
+    products: [
+        .library(
+            name: "libPhoneNumber",
+            targets: ["libPhoneNumber"]
+        )
+    ],
+    targets: [
+        .target(
+            name: "libPhoneNumber",
+            path: "libPhoneNumber",
+            publicHeadersPath: ".",
+            cSettings: [
+                .headerSearchPath("Internal")
+            ]
+        ),
+        .testTarget(
+            name: "libPhoneNumberTests",
+            dependencies: ["libPhoneNumber"],
+            path: "libPhoneNumberTests",
+            sources: [
+                "NBAsYouTypeFormatterTest.m",
+                "NBPhoneNumberParsingPerfTest.m",
+                "NBPhoneNumberUtil+ShortNumberTestHelper.h",
+                "NBPhoneNumberUtil+ShortNumberTestHelper.m",
+                "NBPhoneNumberUtilTest.m",
+                "NBShortNumberInfoTest.m"
+            ]
+        )
+    ]
+)


### PR DESCRIPTION
Support for Swift 5.x, while still support swift 4.2.  
The only change is the addition of a swift 5 or higher copy of package.swift and the swift tools version indication in it.  
The current `Package.swift` does not work with Swift 5 projects.