### PR TITLE
SPM: Update min SDK & fix linker misses

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     name: "libPhoneNumber",
     platforms: [
         .macOS(.v10_10),
-        .iOS(.v8),
+        .iOS(.v9),
         .tvOS(.v9),
         .watchOS(.v2)
     ],
@@ -23,6 +23,9 @@ let package = Package(
             publicHeadersPath: ".",
             cSettings: [
                 .headerSearchPath("Internal")
+            ],
+            linkerSettings: [
+                .linkedFramework("CoreTelephony"),
             ]
         ),
         .testTarget(

--- a/Package@swift-5.0.swift
+++ b/Package@swift-5.0.swift
@@ -6,7 +6,7 @@ let package = Package(
     name: "libPhoneNumber",
     platforms: [
         .macOS(.v10_10),
-        .iOS(.v8),
+        .iOS(.v9),
         .tvOS(.v9),
         .watchOS(.v2)
     ],
@@ -23,6 +23,9 @@ let package = Package(
             publicHeadersPath: ".",
             cSettings: [
                 .headerSearchPath("Internal")
+            ],
+            linkerSettings: [
+                .linkedFramework("CoreTelephony"),
             ]
         ),
         .testTarget(


### PR DESCRIPTION
This removes errors and warnings when building with Xcode 12.