### PR TITLE
CoreTelephony package fixes for watchOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,6 +14,7 @@ let package = Package(
         .target(
             name: "libPhoneNumber",
             path: "libPhoneNumber",
+            exclude: ["GeneratePhoneNumberHeader.sh", "NBPhoneNumberMetadata.plist", "Info.plist"],
             publicHeadersPath: ".",
             cSettings: [
                 .headerSearchPath("Internal")

--- a/Package.swift
+++ b/Package.swift
@@ -4,12 +4,6 @@ import PackageDescription
 
 let package = Package(
     name: "libPhoneNumber",
-    platforms: [
-        .macOS(.v10_10),
-        .iOS(.v9),
-        .tvOS(.v9),
-        .watchOS(.v2)
-    ],
     products: [
         .library(
             name: "libPhoneNumber",
@@ -23,9 +17,6 @@ let package = Package(
             publicHeadersPath: ".",
             cSettings: [
                 .headerSearchPath("Internal")
-            ],
-            linkerSettings: [
-                .linkedFramework("CoreTelephony"),
             ]
         ),
         .testTarget(

--- a/Package@swift-5.0.swift
+++ b/Package@swift-5.0.swift
@@ -25,7 +25,7 @@ let package = Package(
                 .headerSearchPath("Internal")
             ],
             linkerSettings: [
-                .linkedFramework("CoreTelephony"),
+                .linkedFramework("CoreTelephony", .when(platforms: [.iOS])),
             ]
         ),
         .testTarget(

--- a/Package@swift-5.0.swift
+++ b/Package@swift-5.0.swift
@@ -20,6 +20,7 @@ let package = Package(
         .target(
             name: "libPhoneNumber",
             path: "libPhoneNumber",
+            exclude: ["GeneratePhoneNumberHeader.sh", "NBPhoneNumberMetadata.plist", "Info.plist"],
             publicHeadersPath: ".",
             cSettings: [
                 .headerSearchPath("Internal")

--- a/Package@swift-5.0.swift
+++ b/Package@swift-5.0.swift
@@ -25,7 +25,7 @@ let package = Package(
                 .headerSearchPath("Internal")
             ],
             linkerSettings: [
-                .linkedFramework("CoreTelephony", .when(platforms: [.iOS])),
+                .linkedFramework("CoreTelephony", .when(platforms: [.iOS, .macOS])),
             ]
         ),
         .testTarget(

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -1,0 +1,46 @@
+// swift-tools-version:5.5
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+import PackageDescription
+
+let package = Package(
+    name: "libPhoneNumber",
+    platforms: [
+        .macOS(.v10_10),
+        .macCatalyst(.v13),
+        .iOS(.v9),
+        .tvOS(.v9),
+        .watchOS(.v2)
+    ],
+    products: [
+        .library(
+            name: "libPhoneNumber",
+            targets: ["libPhoneNumber"]
+        )
+    ],
+    targets: [
+        .target(
+            name: "libPhoneNumber",
+            path: "libPhoneNumber",
+            publicHeadersPath: ".",
+            cSettings: [
+                .headerSearchPath("Internal")
+            ],
+            linkerSettings: [
+                .linkedFramework("CoreTelephony", .when(platforms: [.iOS, .macOS, .macCatalyst])),
+            ]
+        ),
+        .testTarget(
+            name: "libPhoneNumberTests",
+            dependencies: ["libPhoneNumber"],
+            path: "libPhoneNumberTests",
+            sources: [
+                "NBAsYouTypeFormatterTest.m",
+                "NBPhoneNumberParsingPerfTest.m",
+                "NBPhoneNumberUtil+ShortNumberTestHelper.h",
+                "NBPhoneNumberUtil+ShortNumberTestHelper.m",
+                "NBPhoneNumberUtilTest.m",
+                "NBShortNumberInfoTest.m"
+            ]
+        )
+    ]
+)

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -21,6 +21,7 @@ let package = Package(
         .target(
             name: "libPhoneNumber",
             path: "libPhoneNumber",
+            exclude: ["GeneratePhoneNumberHeader.sh", "NBPhoneNumberMetadata.plist", "Info.plist"],
             publicHeadersPath: ".",
             cSettings: [
                 .headerSearchPath("Internal")


### PR DESCRIPTION
I added the linker dependency in https://github.com/iziz/libPhoneNumber-iOS/pull/333

watchOS does not contain this framework, so things won't correctly link by specifying it directly.
Looking at the Apple docs, this framework is only available for iOS and macOS, so I have updated the setting.
macOS linking is required for a Catalyst app to compile, and is available as of macOS 10.10.

I have verified it against my app on Xcode 12.5 with iOS, watchOS, and macOS Catalyst.

Further, I cleaned up the v4.1 Package.swift file by removing invalid arguments.