### PR TITLE
Disallow default init for NBPhoneNumberUtil.

### DIFF
--- a/libPhoneNumber/NBPhoneNumberUtil.h
+++ b/libPhoneNumber/NBPhoneNumberUtil.h
@@ -16,6 +16,8 @@
 + (NBPhoneNumberUtil *)sharedInstance;
 - (instancetype)initWithMetadataHelper:(NBMetadataHelper *)helper;
 
+- (instancetype)init NS_UNAVAILABLE;
+
 @property(nonatomic, strong, readonly) NSDictionary *DIGIT_MAPPINGS;
 
 // regular expressions

--- a/libPhoneNumberShortNumber/NBShortNumberUtil.m
+++ b/libPhoneNumberShortNumber/NBShortNumberUtil.m
@@ -38,7 +38,7 @@ static NSString *const PLUS_CHARS_PATTERN = @"[+\uFF0B]+";
 
 - (instancetype)init {
   return [self initWithMetadataHelper:[[NBShortNumberMetadataHelper alloc] init]
-                      phoneNumberUtil:[[NBPhoneNumberUtil alloc] init]];
+                      phoneNumberUtil:[NBPhoneNumberUtil sharedInstance]];
 }
 
 - (BOOL)isPossibleShortNumber:(NBPhoneNumber *)phoneNumber forRegion:(NSString *)regionDialingFrom {


### PR DESCRIPTION
sharedInstance must be used. Fix issue with instantiation in ShortNumberUtil.