### PR TITLE
Check if rangeOfString found something

### DIFF
--- a/libPhoneNumber/NBAsYouTypeFormatter.m
+++ b/libPhoneNumber/NBAsYouTypeFormatter.m
@@ -810,10 +810,12 @@ static const NSUInteger NBMinLeadingDigitsLength = 3;
     NSString *prefixBeforeNationalNumberStr = [self.prefixBeforeNationalNumber_ copy];
     NSRange lastRange = [prefixBeforeNationalNumberStr rangeOfString:self.nationalPrefixExtracted_
                                                              options:NSBackwardsSearch];
-    /** @type {number} */
-    NSUInteger indexOfPreviousNdd = lastRange.location;
-    self.prefixBeforeNationalNumber_ = [[prefixBeforeNationalNumberStr
-        substringWithRange:NSMakeRange(0, indexOfPreviousNdd)] mutableCopy];
+    if (lastRange.length > 0) {
+      /** @type {number} */
+      NSUInteger indexOfPreviousNdd = lastRange.location;
+      self.prefixBeforeNationalNumber_ = [[prefixBeforeNationalNumberStr
+                                           substringWithRange:NSMakeRange(0, indexOfPreviousNdd)] mutableCopy];
+    }
   }
 
   return self.nationalPrefixExtracted_ != [self removeNationalPrefixFromNationalNumber_];


### PR DESCRIPTION
We had this crash when `lastRange.location` was `NSNotFound` for an edgecasey phone number / locale combination. This adds a length check.