### PR TITLE
[Issue #433] Fix Cocoapod inclusion of Privacy Manifest

### DIFF
--- a/libPhoneNumber-iOS.podspec
+++ b/libPhoneNumber-iOS.podspec
@@ -35,8 +35,8 @@ Pod::Spec.new do |s|
                     'libPhoneNumber/**/*.{h,m}',
                    ]
 
-  s.resources   = [
-                    'libPhoneNumber/PrivacyInfo.xcprivacy'
-                  ]
+  s.resource_bundles = {
+                       'libPhoneNumber-iOS' => ['libPhoneNumber/PrivacyInfo.xcprivacy']
+                   }
 
 end


### PR DESCRIPTION
* Incorrectly including the manifest as a resource for the entire consuming product
* Changing to include via a library specific resource bundle

This is intended as a fix for Issue #433 