### PR TITLE
Add missing Foundation import to libPhoneNumber.h

### DIFF
--- a/libPhoneNumber/libPhoneNumber.h
+++ b/libPhoneNumber/libPhoneNumber.h
@@ -6,6 +6,8 @@
 //  Copyright (c) 2015 ohtalk.me. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
+
 //! Project version number for libPhoneNumber-iOS.
 FOUNDATION_EXPORT double libPhoneNumber_iOSVersionNumber;
 


### PR DESCRIPTION
In [this commit](https://github.com/mbernson/libPhoneNumber-iOS/commit/b1ef5c1390daa5acefa3bd0e20cb312e2d86f01b#diff-617553be46aa9a6e9aeae4e8925455d0a024f4990d75f80f88a08c558ae06914), the import statement at the top of `libPhoneNumber.h` was removed. This causes the build to fail because the `FOUNDATION_EXPORT` macro is undefined. 

This PR adds an import for `#import <Foundation/Foundation.h>` to fix it.