### PR TITLE
Fix Package.swift parse errors

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     products: [
         .library(
             name: "libPhoneNumber",
-            targets: ["libPhoneNumber"],
+            targets: ["libPhoneNumber"]
         ),
         .library(
             name: "libPhoneNumberGeocoding",
@@ -32,12 +32,12 @@ let package = Package(
             resources: [
                 .copy("libPhoneNumberMetaDataForTesting.zip")
             ],
-            publicHeadersPath: ".",
+            publicHeadersPath: "."
         ),
         .target(
             name: "libPhoneNumberInternal",
             path: "libPhoneNumberInternal",
-            publicHeadersPath: ".",
+            publicHeadersPath: "."
         ),
         .target(
             name: "libPhoneNumber",
@@ -61,7 +61,7 @@ let package = Package(
                 "libPhoneNumber",
                 "libPhoneNumberTestsCommon",
             ],
-            path: "libPhoneNumberTests",
+            path: "libPhoneNumberTests"
         ),
         .target(
             name: "libPhoneNumberGeocodingMetaData",
@@ -69,7 +69,7 @@ let package = Package(
             resources: [
                 .copy("GeocodingMetaData.bundle")
             ],
-            publicHeadersPath: ".",
+            publicHeadersPath: "."
         ),
         .target(
             name: "libPhoneNumberGeocoding",
@@ -82,7 +82,7 @@ let package = Package(
                 "README.md",
                 "Info.plist",
             ],
-            publicHeadersPath: ".",
+            publicHeadersPath: "."
         ),
         .testTarget(
             name: "libPhoneNumberGeocodingTests",
@@ -101,7 +101,7 @@ let package = Package(
                 "libPhoneNumber",
             ],
             path: "libPhoneNumberShortNumberInternal",
-            publicHeadersPath: ".",
+            publicHeadersPath: "."
         ),
         .target(
             name: "libPhoneNumberShortNumber",
@@ -113,7 +113,7 @@ let package = Package(
                 "README.md",
                 "Info.plist",
             ],
-            publicHeadersPath: ".",
+            publicHeadersPath: "."
         ),
         .testTarget(
             name: "libPhoneNumberShortNumberTests",
@@ -121,7 +121,7 @@ let package = Package(
                 "libPhoneNumberShortNumber",
                 "libPhoneNumberTestsCommon",
             ],
-            path: "libPhoneNumberShortNumberTests",
+            path: "libPhoneNumberShortNumberTests"
         ),
     ]
 )


### PR DESCRIPTION
**Issue:**
Swift Package Manager fails to resolve dependencies, showing the error below:

<img width="643" height="289" alt="Screenshot 2025-12-03 at 15 41 42" src="https://github.com/user-attachments/assets/d672a2a0-8a7f-44bc-9638-ca7738538b31" />

**Steps to Reproduce:**
- Add the library (latest version `1.3.0`) via Swift Package Manager in XCode.
- Observe the error shown in **Issue:** section.

**Root Cause:**
Running `xcrun --toolchain swift-5.5 swift package resolve` in the root of project revealed multiple parsing issues. The culprit? **Illegal trailing commas** in `Package.swift` file that are incompatible with Swift Tools 5.5.
